### PR TITLE
Register to DHCP server with hostname

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -8,7 +8,7 @@ MAC=`cat /params/config/.product_config | grep MAC | cut -c16-27 | sed 's/\(..\)
 ## Start Wifi:
 insmod /driver/8189es.ko rtw_initmac="$MAC"
 wpa_supplicant -B -i wlan0 -c $CONFIGPATH/wpa_supplicant.conf -P /var/run/wpa_supplicant.pid
-udhcpc -i wlan0 -p /var/run/udhcpc.pid -b
+udhcpc -i wlan0 -p /var/run/udhcpc.pid -b -x hostname:`hostname`
 
 ## Start Audio:
 insmod /driver/audio.ko


### PR DESCRIPTION
Currently camera registers as 'Unknown' to the DHCP server, this change uses the hostname as the dhcp client name.