### PR TITLE
 OSD configurable with webinterface

### DIFF
--- a/firmware_mod/config/osd
+++ b/firmware_mod/config/osd
@@ -1,0 +1,1 @@
+OSD="-D DafangHacks_%H:%M:%S_%d.%m.%Y  -d UP"

--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -3,6 +3,10 @@ PIDFILE="/run/v4l2rtspserver-master-h264.pid"
 NIGHTFILE="/run/v4l2rtspserver-master-h264.night"
 export LD_LIBRARY_PATH='/thirdlib:/system/lib'
 
+if [ -f /system/sdcard/config/osd ]; then
+source /system/sdcard/config/osd  2>/dev/null
+fi
+
 status()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
@@ -21,7 +25,7 @@ else
  	/system/sdcard/controlscripts/rtsp-mjpeg stop
 	/system/sdcard/controlscripts/rtsp-h264-with-segmentation stop	
 	killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
-      	/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master  &>/dev/null &
+      	/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master $OSD &>/dev/null &
   echo "$!" > "$PIDFILE"
 fi
 }
@@ -36,7 +40,7 @@ else
   /system/sdcard/controlscripts/rtsp-mjpeg stop
   /system/sdcard/controlscripts/rtsp-h264-with-segmentation stop
   touch $NIGHTFILE
-  /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -n &>/dev/null &
+  /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -n $OSD &>/dev/null &
   echo "$!" > "$PIDFILE"
 fi
 }

--- a/firmware_mod/controlscripts/rtsp-h264-with-segmentation
+++ b/firmware_mod/controlscripts/rtsp-h264-with-segmentation
@@ -3,6 +3,10 @@ PIDFILE="/run/v4l2rtspserver-master-h264-s.pid"
 NIGHTFILE="/run/v4l2rtspserver-master-h264-s.night"
 export LD_LIBRARY_PATH='/thirdlib:/system/lib'
 
+if [ -f /system/sdcard/config/osd ]; then
+source /system/sdcard/config/osd  2>/dev/null
+fi
+
 
 status()
 {
@@ -22,7 +26,7 @@ else
         /system/sdcard/controlscripts/rtsp-mjpeg stop
         /system/sdcard/controlscripts/rtsp-h264 stop
         killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
-      /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -S &>/dev/null &
+      /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master $OSD -S &>/dev/null &
   echo "$!" > "$PIDFILE"
 fi
 }
@@ -38,7 +42,7 @@ else
         /system/sdcard/controlscripts/rtsp-mjpeg stop
         /system/sdcard/controlscripts/rtsp-h264 stop
   	touch $NIGHTFILE
-      	/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -S -n &>/dev/null &
+      	/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master $OSD -S -n &>/dev/null &
   echo "$!" > "$PIDFILE"
 fi
 }

--- a/firmware_mod/controlscripts/rtsp-mjpeg
+++ b/firmware_mod/controlscripts/rtsp-mjpeg
@@ -3,6 +3,9 @@ PIDFILE="/run/v4l2rtspserver-master-mjpeg.pid"
 NIGHTFILE="/run/v4l2rtspserver-master-mjpeg.night"
 export LD_LIBRARY_PATH='/thirdlib:/system/lib'
 
+if [ -f /system/sdcard/config/osd ]; then 
+source /system/sdcard/config/osd  2>/dev/null
+fi
 
 status()
 {
@@ -22,7 +25,7 @@ else
   /system/sdcard/controlscripts/rtsp-h264 stop
   /system/sdcard/controlscripts/rtsp-h264-with-segmentation stop	
   killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
-  /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG &>/dev/null &
+  /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG ${OSD} &>/dev/null &
   echo "$!" > "$PIDFILE"
 fi
 }
@@ -37,7 +40,7 @@ else
   /system/sdcard/controlscripts/rtsp-h264 stop
   /system/sdcard/controlscripts/rtsp-h264-with-segmentation stop
   touch $NIGHTFILE  
-  /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG -n &>/dev/null &
+  /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG ${OSD} -n &>/dev/null &
   echo "$!" > "$PIDFILE"
 fi
 }

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -56,11 +56,17 @@ insmod /system/sdcard/driver/sensor_jxf22.ko data_interface=2 pwdn_gpio=-1 reset
 ## Start Webserver:
 /system/sdcard/bin/boa -c /system/sdcard/config/
 
+## Get OSD-Information
+if [ -f /system/sdcard/config/osd ]; then
+source /system/sdcard/config/osd  2>/dev/null
+fi
+
 ## Autostart
  for i in `ls /system/sdcard/config/autostart/`; do /system/sdcard/config/autostart/$i; done
 
 #Start
-/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -D "DafangHacks %I:%M:%S %d.%m.%Y" -d UP &>/dev/null &
+
+/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master $OSD &>/dev/null &
 
 echo "Startup finished!"
 

--- a/firmware_mod/www/cgi-bin/status.cgi
+++ b/firmware_mod/www/cgi-bin/status.cgi
@@ -198,10 +198,22 @@ PATH="/bin:/sbin:/usr/bin:/media/mmcblk0p2/data/bin:/media/mmcblk0p2/data/sbin:/
 IP=$(ifconfig wlan0 |grep "inet addr" |awk '{print $2}' |awk -F: '{print $2}')
 echo "Path to feed : <a href='rtsp://$(echo $IP):8554/unicast'>rtsp://$(echo $IP):8554/unicast</a></br>"
 cat << EOF
+</td>
 
-
+<tr>
+  <th>OSD-Display</th>
+  <td> 
+  <form style="margin: 0px" action="/cgi-bin/action.cgi?cmd=osd" method="post"> 
+  <input type="checkbox" name="OSDenable" value="enabled" $(if [ -f /system/sdcard/config/osd ]; then echo checked; fi)> Enable 
+  <input type="radio" id="up" name="Position" value="UP"  $(if [ `cat /system/sdcard/config/osd | awk '{print $NF}' | sed -e s/\"//` == "UP" ]; then echo checked; fi)>Up 
+  <input type="radio" id="down" name="Position" value="DOWN"  $(if [ `cat /system/sdcard/config/osd | awk '{print $NF}' | sed -e s/\"//` == "DOWN" ]; then echo checked; fi)>Down
+  Text: <input id="osdtext" name="osdtext" type="text" size="25" value="$(cat /system/sdcard/config/osd | sed -e s/".*-D "// | sed -e s/" *-d.*$"//)"/>
+  <input type="submit" value="Set"/><br>
+  Enter time-variables in <a href="http://strftime.org/" target="_blank">strftime</a> format 
   </td>
+
 </tr>
+
 <tr>
   <th>Start original Xiaomi Software:</th>
   <td>


### PR DESCRIPTION
Works quite well with one problem - probably you've got an idea?
I don't have a clue how to use a variable with a blank when starting v42lrtspserver, tried all combinations with quotation marks, double, single whatever. The OSD-Text will end after the first blank:

```
[root@Pucki-Cam:tmp]# cat /system/sdcard/config/osd
OSD='-D "DafangHacks %H:%M:%S %d.%m.%Y" -d UP'
[root@Pucki-Cam:tmp]# /system/sdcard/bin/v4l2rtspserver-master -fMJPG $OSD &
```
(skipped the notices)
the RTSP-Server ist running, OSD is **"Dafang Hacks** (including the quotation marks)

The command is alright anyway
```
[root@Pucki-Cam:tmp]# ps w | grep v4l
 1455 root      129m R    /system/sdcard/bin/v4l2rtspserver-master -fMJPG -D "DafangHacks %H:%M:%S %d.%m.%Y" -d UP
```

if I start this from the command line everything is fine and the OSD works as designed.

Putting the same string in a variable like
```
[root@Pucki-Cam:tmp]# TEST='/system/sdcard/bin/v4l2rtspserver-master -fMJPG -D "DafangHacks %H:%M:%S %d.%m.%Y" -d UP'
[root@Pucki-Cam:tmp]# echo $TEST
/system/sdcard/bin/v4l2rtspserver-master -fMJPG -D "DafangHacks %H:%M:%S %d.%m.%Y" -d UP
[root@Pucki-Cam:tmp]# $TEST
```

Im sure the answer cannot be that hard, but I'm lost.

So every blank is replaced by a underscore - thats the only problem until now. 

best, 
danny

![image](https://user-images.githubusercontent.com/33186930/36055734-dd2f780c-0dfe-11e8-96eb-662487ddfba4.png)



