### PR TITLE
Reftresh Daemon auto-night-detection

### DIFF
--- a/firmware_mod/controlscripts/auto-night-detection
+++ b/firmware_mod/controlscripts/auto-night-detection
@@ -1,33 +1,50 @@
 #!/bin/sh
-PIDFILE="/run/auto-night-detection.pid"
+returnLog(){
+  if [ $1 == "s" ]; then
+    echo "[`date +"%Y-%m-%d %H:%M:%S"`][SUCCESS] - $2"
+  elif [ $1 == "i" ]; then
+    echo "[`date +"%Y-%m-%d %H:%M:%S"`][INFO] - $2"
+  elif [ $1 == "e" ]; then
+    echo "[`date +"%Y-%m-%d %H:%M:%S"`][ERROR] - $2"
+  fi
+}
+# returnLog "s" "Log data"
 
-status()
-{
-  pid="$(cat "$PIDFILE" 2>/dev/null)"
-  if [ "$pid" ]; then
-    kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
+PIDFILE="/run/nightvision-detection.pid"
+PID="$(cat "$PIDFILE" 2>/dev/null)"
+
+status(){
+  if [ "$PID" ]; then
+    returnLog "s" "Daemon Night Vision Detection is running. PID: $PID" || return 1
+  else
+    returnLog "i" "Daemon Night Vision Detection is stopped." || return 0
   fi
 }
 
-start()
-{
-if [ -f /run/auto-night-detection.pid ]; then
-echo "Auto Night Detection already running";
-
-else
-
-  LOG=/dev/null
-  echo "Starting Auto Night Detection"
-  /system/sdcard/bin/busybox nohup /system/sdcard/scripts/ldr.sh &>/dev/null &  
-  echo "$!" > "$PIDFILE"
-fi
+start(){
+  if ! [ -f $PIDFILE ]; then
+    /system/sdcard/bin/busybox nohup /system/sdcard/scripts/ldr.sh &>/dev/null &
+    echo "$!" > "$PIDFILE"
+    if [ `ps | grep ldr.sh | grep -v grep | wc -l` -eq 1 ]; then
+      returnLog "i" "Starting Daemon Night Vision Detection. PID: $(cat "$PIDFILE" 2>/dev/null)."
+    else
+      returnLog "e" "An error occurred while starting Daemon Night Vision Detection."
+    fi
+  else
+    returnLog "i" "Daemon Night Vision Detection already running. PID: $PID."
+  fi
 }
 
-stop()
-{
-  pid="$(cat "$PIDFILE" 2>/dev/null)"
-  if [ "$pid" ]; then
-     kill $pid &&  rm "$PIDFILE"
+stop(){
+  if [ "$PID" ]; then
+     kill $PID &&  rm "$PIDFILE"
+     if [ $? -eq 0 ]; then
+       returnLog "s" "Stoping Daemon Night Vision Detection."
+     else
+       returnLog "e" "An error occurred while stopping Daemon Night Vision Detection."
+     fi
+  else
+    returnLog "i" "Daemon Night Vision Detection already stopped."
   fi
 }
 
@@ -39,4 +56,3 @@ else
     ;;
   esac
 fi
-


### PR DESCRIPTION
Added return informations and valid operations.
Script is better.

For testing compatible, because I use my custom modyfication version software.
I upload with adjust to Dafang-Hacks without testing.

![image](https://user-images.githubusercontent.com/7155051/36644258-c2e5abaa-1a57-11e8-9622-53a08d634cf6.png)

```bash
[root@Dafang:~]# /system/sdcard/controlscripts/nightvision-detection status
[2018-02-25 17:57:50][INFO] - Daemon Night Vision Detection is stopped.
[root@Dafang:~]# /system/sdcard/controlscripts/nightvision-detection stop
[2018-02-25 17:57:53][INFO] - Daemon Night Vision Detection already stopped.
[root@Dafang:~]# /system/sdcard/controlscripts/nightvision-detection start
[2018-02-25 17:57:58][INFO] - Starting Daemon Night Vision Detection. PID: 8206.
[root@Dafang:~]# /system/sdcard/controlscripts/nightvision-detection start
[2018-02-25 17:58:00][INFO] - Daemon Night Vision Detection already running. PID: 8206.
[root@Dafang:~]# /system/sdcard/controlscripts/nightvision-detection status
[2018-02-25 17:58:04][SUCCESS] - Daemon Night Vision Detection is running. PID: 8206
[root@Dafang:~]# /system/sdcard/controlscripts/nightvision-detection stop
[2018-02-25 17:58:09][SUCCESS] - Stoping Daemon Night Vision Detection.
```