### PR TITLE
Remove extra backtick

### DIFF
--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -161,7 +161,7 @@ if [ -n "$F_cmd" ]; then
 	;;
 	
 	setldravg)
-	ldravg=´$(printf '%b' "${F_avg/%/\\x}")
+	ldravg=$(printf '%b' "${F_avg/%/\\x}")
 	ldravg=$(echo $ldravg | sed "s/[^0-9]//g")
 	echo AVG=$ldravg > /system/sdcard/config/ldr-average
 	echo "Average set to $ldravg iterations."


### PR DESCRIPTION
I was reviewing the code after purchasing one of these cameras.  I noticed that there *may* be an extra backtick here.  I can't currently run this code (camera is still on the way) but thought I should point it out.  

