### PR TITLE
fix misleading ir cut state

### DIFF
--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -46,12 +46,12 @@ if [ -n "$F_cmd" ]; then
     setgpio 49 1
     ;;
   ir_cut_on)
-    setgpio 25 1
-    setgpio 26 0
-    ;;
-  ir_cut_off)
     setgpio 25 0
     setgpio 26 1
+    ;;
+  ir_cut_off)
+    setgpio 25 1
+    setgpio 26 0
     ;;
   motor_left)
     /system/sdcard/bin/motor -d l -s 100


### PR DESCRIPTION
ir cut/filter on is needed with daylight, ir cut off at night when we use the ir leds to illuminate the scene.