### PR TITLE
Add SHA256 and SHA3-256 checksums

### DIFF
--- a/hacks/install_cfw.md
+++ b/hacks/install_cfw.md
@@ -1,6 +1,8 @@
 ## Installation of the microSD bootloader
 
-1. Download [CFW-Binary](/hacks/cfw/cfw-1.3.bin). Ensure that the downloaded File-size is something about 11.1MB . 
+1. Download [CFW-Binary](/hacks/cfw/cfw-1.3.bin). Verify the SHA256 and/or SHA3-256 checksums to ensure file integrity.
+  - SHA2-256: `2a23e136906d0ba13d1bb9fe7da52c2eb49c58ccce97be29c91259c2011894ae`
+  - SHA3-256: `d45826d5b471564366b3b9435509df7e8a2c0720656ea2b4bcac6dd0b42cc3eb`
 2. Format your microSD to FAT. NTFS, EXFAT etc. won't work.
 2. Put it to microSD and rename it to "demo.bin". There should be no other files on the microSD! This is really important and it won't work if there are any other files on there.
 3. Shutdown the Dafang camera, remove the power cable and plug the microSD into the Dafang


### PR DESCRIPTION
Rather than relying on approximate size, we now include the checksums to ensure the file is not corrupt.