### PR TITLE
Add commented config option for hidden SSIDs

### DIFF
--- a/firmware_mod/config/wpa_supplicant.conf
+++ b/firmware_mod/config/wpa_supplicant.conf
@@ -4,6 +4,8 @@ ap_scan=1
 
 network={
         ssid="SSID"
+        # Uncomment to connect to Hidden SSIDs
+        #scan_ssid=1 
         key_mgmt=WPA-PSK
         pairwise=CCMP TKIP
         group=CCMP TKIP WEP104 WEP40


### PR DESCRIPTION
This is required to connect to wireless networks with hidden SSIDs.

Relates to Issue #144 