### PR TITLE
Cleaner autostart for rtsp. Fix for Issue #186

### DIFF
--- a/firmware_mod/config/rtspserver.dist
+++ b/firmware_mod/config/rtspserver.dist
@@ -1,0 +1,17 @@
+#######################################################################
+# Edit this file and move it to /system/sdcard/config/rtspserver.conf #
+# if you need to add options, otherwise defaults will be used         #
+#######################################################################
+
+# Configure RTSP Servers
+# Use /system/sdcard/bin/v4l2rtspserver-master -h to see available options
+
+# H264 RTSP server options
+# Examples:
+# RTSPH264OPTS="-S -W960 -H540"
+RTSPH264OPTS=""
+
+# MJPEG RTSP server options
+# Examples:
+# RTSPMJPEGOPTS="-W960 -H540"
+RTSPMJPEGOPTS=""

--- a/firmware_mod/controlscripts/configureOsd
+++ b/firmware_mod/controlscripts/configureOsd
@@ -3,10 +3,11 @@
 ## Get OSD-Information
 if [ -f /system/sdcard/config/osd ]; then
     source /system/sdcard/config/osd  2>/dev/null
-	/system/sdcard/bin/setconf -k o -v "${OSD}" 2>/dev/null
-    /system/sdcard/bin/setconf -k c -v ${COLOR} 2>/dev/null
-    /system/sdcard/bin/setconf -k s -v ${SIZE} 2>/dev/null
-    /system/sdcard/bin/setconf -k x -v ${POSY} 2>/dev/null
-    /system/sdcard/bin/setconf -k w -v ${FIXEDW} 2>/dev/null
-	/system/sdcard/bin/setconf -k p -v ${SPACE} 2>/dev/null
+    # Call setconf only if we have something to set, to avoid outputing error messages
+    [ ! -z "${OSD}" ] && /system/sdcard/bin/setconf -k o -v "${OSD}" 2>/dev/null
+    [ ! -z "${COLOR}" ] && /system/sdcard/bin/setconf -k c -v ${COLOR} 2>/dev/null
+    [ ! -z "${SIZE}" ] && /system/sdcard/bin/setconf -k s -v ${SIZE} 2>/dev/null
+    [ ! -z "${POSY}" ] && /system/sdcard/bin/setconf -k x -v ${POSY} 2>/dev/null
+    [ ! -z "${FIXEDW}" ] && /system/sdcard/bin/setconf -k w -v ${FIXEDW} 2>/dev/null
+    [ ! -z "${SPACE}" ] && /system/sdcard/bin/setconf -k p -v ${SPACE} 2>/dev/null
 fi

--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -2,6 +2,10 @@
 PIDFILE="/run/v4l2rtspserver-master-h264.pid"
 export LD_LIBRARY_PATH='/thirdlib:/system/lib'
 
+if [ -f /system/sdcard/config/rtspserver.conf ]; then
+  source /system/sdcard/config/rtspserver.conf
+fi
+
 if [ -f /system/sdcard/config/osd ]; then
   source /system/sdcard/config/osd 2>/dev/null
 fi
@@ -10,6 +14,7 @@ status()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
   if [ "$pid" ]; then
+    # Prints PID: $pid if exists and returns 0(no error) else returns 1(error condition)
     kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
   fi
 }
@@ -20,19 +25,20 @@ start()
     echo "A v4l2rtspserver is already running, please stop it or reboot"
   else
     echo "Starting v4l2rtspserver-master"
-      /system/sdcard/controlscripts/rtsp-mjpeg stop
-      killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
-      ## Configure OSD
-      if [ -f /system/sdcard/controlscripts/configureOsd ]; then
-        source /system/sdcard/controlscripts/configureOsd  2>/dev/null
-      fi
+    /system/sdcard/controlscripts/rtsp-mjpeg stop
+    # We no longer start v4l2rtspserver-master in run.sh
+    #killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
+    ## Configure OSD
+    if [ -f /system/sdcard/controlscripts/configureOsd ]; then
+      source /system/sdcard/controlscripts/configureOsd  2>/dev/null
+    fi
 
-      ## Configure Motion
-      if [ -f /system/sdcard/controlscripts/configureMotion ]; then
-        source /system/sdcard/controlscripts/configureMotion  2>/dev/null
-      fi
-      /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master &>/dev/null &
-      echo "$!" > "$PIDFILE"
+    ## Configure Motion
+    if [ -f /system/sdcard/controlscripts/configureMotion ]; then
+      source /system/sdcard/controlscripts/configureMotion  2>/dev/null
+    fi
+    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master $RTSPH264OPTS &>/dev/null &
+    echo "$!" > "$PIDFILE"
   fi
 }
 

--- a/firmware_mod/controlscripts/rtsp-mjpeg
+++ b/firmware_mod/controlscripts/rtsp-mjpeg
@@ -2,6 +2,10 @@
 PIDFILE="/run/v4l2rtspserver-master-mjpeg.pid"
 export LD_LIBRARY_PATH='/thirdlib:/system/lib'
 
+if [ -f /system/sdcard/config/rtspserver.conf ]; then
+  source /system/sdcard/config/rtspserver.conf
+fi
+
 if [ -f /system/sdcard/config/osd ]; then 
   source /system/sdcard/config/osd 2>/dev/null
 fi
@@ -10,6 +14,7 @@ status()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
   if [ "$pid" ]; then
+    # Prints PID: $pid if exists and returns 0(no error) else returns 1(error condition)
     kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
   fi
 }
@@ -21,16 +26,18 @@ start()
   else
     echo "Starting v4l2rtspserver-master with parameter -fMJPG"
     /system/sdcard/controlscripts/rtsp-h264 stop
-    killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
+    # We no longer start v4l2rtspserver-master in run.sh
+    #killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
     ## Configure OSD
     if [ -f /system/sdcard/controlscripts/configureOsd ]; then
       source /system/sdcard/controlscripts/configureOsd  2>/dev/null
     fi
+
     ## Configure Motion
     if [ -f /system/sdcard/controlscripts/configureMotion ]; then
       source /system/sdcard/controlscripts/configureMotion  2>/dev/null
     fi
-    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG &>/dev/null &
+    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG $RTSPMJPEGOPTS &>/dev/null &
     echo "$!" > "$PIDFILE"
   fi
 }
@@ -39,7 +46,7 @@ stop()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
   if [ "$pid" ]; then
-     kill "$pid" & rm "$PIDFILE" 1> /dev/null 2>&1
+    kill "$pid" & rm "$PIDFILE" 1> /dev/null 2>&1
   fi
 }
 

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -72,10 +72,6 @@ for i in /system/sdcard/config/autostart/*; do
   $i
 done
 
-#Start rtsp server
-# Choose only one of the servers below to uncomment if desired
-#/system/sdcard/controlscripts/rtsp-mjpeg start
-/system/sdcard/controlscripts/rtsp-h264 start
-
+# Removing rtsp server startup here since it should be started if necessary in config/autostart
 
 echo "Startup finished!"

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -72,8 +72,10 @@ for i in /system/sdcard/config/autostart/*; do
   $i
 done
 
-#Start
-/system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master &>/dev/null &
+#Start rtsp server
+# Choose only one of the servers below to uncomment if desired
+#/system/sdcard/controlscripts/rtsp-mjpeg start
+/system/sdcard/controlscripts/rtsp-h264 start
 
 
 echo "Startup finished!"


### PR DESCRIPTION
When autostarting rtsp server, instead of doing so explicitly in run.sh, now call the controlscripts/rtsp scripts.  This allows localization of the start and stop of the service.  Also fixes problem reported in Issue #186.