### PR TITLE
lighttpd.conf: Make default port 80, add mimetypes for js and css

### DIFF
--- a/firmware_mod/config/lighttpd.conf
+++ b/firmware_mod/config/lighttpd.conf
@@ -1,12 +1,14 @@
 server.document-root = "/system/sdcard/www" 
 
-server.port = 7000
+server.port = 80
 
 mimetype.assign = (
   ".html" => "text/html", 
   ".txt" => "text/plain",
   ".jpg" => "image/jpeg",
-  ".png" => "image/png" 
+  ".png" => "image/png",
+  ".css" => "text/css",
+  ".js" => "text/javascript"
 )
 index-file.names = ( "index.html" )
 server.modules              = ("mod_auth", 


### PR DESCRIPTION
Since lighttpd is an alternative to boa, I thought it made more sense that it should also be listening on port 80 instead.

The config was also missing the mimetypes for css and js.

An additional aside,  I noticed in ``/var/log/error.log`` there appears to be a warning with the default lighttpd config:
``
(server.c.1452) WARNING: unknown config-key: accesslog.filename (ignored)
``
I did not fix it in this PR since it's just a warning and the required module may be added in a future update.
