### PR TITLE
Fixes wrong state returned for rtsp_server [#248]

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -139,9 +139,9 @@ rtsp_server(){
     /system/sdcard/controlscripts/rtsp-h264 stop
     ;;
   status)
-    status=$(pidof v4l2rtspserver-master)
+    status="$(pidof v4l2rtspserver-master)"
     case $status in
-      0)
+      "")
         echo "OFF"
         ;;
       *)


### PR DESCRIPTION
Fixes #248. Script function rtsp_server was always returning state "ON" even if not started.
Regression was introduced in #207.
