### PR TITLE
Fix rtsp-h264 state response

### DIFF
--- a/firmware_mod/www/cgi-bin/state.cgi
+++ b/firmware_mod/www/cgi-bin/state.cgi
@@ -30,7 +30,12 @@ if [ -n "$F_cmd" ]; then
     ;;
 
   rtsp_h264)
-    echo $(rtsp_server status)
+    if [ -f /run/v4l2rtspserver-master-h264.pid ];
+      then rtsp_h264="ON";
+    else
+      rtsp_h264="OFF";
+    fi
+    echo $rtsp_h264
     ;;
 
   rtsp_mjpeg)


### PR DESCRIPTION
This was causing the status of "RTSP H264" to be wrongly reported in the UI.

We cannot use ``rtsp_server`` from ``common_functions.sh`` because that is non-specific to h264, if either rtsp-h264 or rtsp-mjpeg is activated, ``rtsp_server`` reports as "ON"

Regression introduced in #207