### PR TITLE
Update sendPictureMail.sh

### DIFF
--- a/firmware_mod/scripts/sendPictureMail.sh
+++ b/firmware_mod/scripts/sendPictureMail.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 boundary="ZZ_/afg6432dfgkl.94531q"
-FILENAME=capture.jpg
+FILENAME=$(date "+%Y%m%d%H%M%S-")
+MAILDATE=$(date -R)
 
 . /system/sdcard/config/sendmail.conf
 
@@ -11,6 +12,7 @@ FILENAME=capture.jpg
 printf '%s\n' "From: ${FROMNAME}
 To: ${TO}
 Subject: ${SUBJECT}
+Date: ${MAILDATE}
 Mime-Version: 1.0
 Content-Type: multipart/mixed; boundary=\"$boundary\"
 
@@ -27,15 +29,15 @@ do
 	# and produce the corresponding part,
 	printf '%s\n' "--${boundary}
 Content-Type: image/jpeg
-Content-Transfer-Encoding: uuencode
-Content-Disposition: attachment; filename=\"${i}${FILENAME}\"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=\"${FILENAME}${i}.jpg\"
 "
 
     if [ ${QUALITY} -eq -1 ]
     then
-        /system/sdcard/bin/getimage | /system/sdcard/bin/busybox uuencode ${i}${FILENAME}
+        /system/sdcard/bin/getimage | /system/sdcard/bin/openssl enc -base64
     else
-       /system/sdcard/bin/getimage |  /system/sdcard/bin/jpegoptim -m${QUALITY} --stdin --stdout  | /system/sdcard/bin/busybox uuencode ${i}${FILENAME}
+       /system/sdcard/bin/getimage |  /system/sdcard/bin/jpegoptim -m${QUALITY} --stdin --stdout  | /system/sdcard/bin/openssl enc -base64
 
     fi
 
@@ -49,6 +51,7 @@ done
 
 # print last boundary with closing --
 printf '%s\n' "--${boundary}--"
+printf '%s\n' "-- End --"
 
 } |  /system/sdcard/bin/busybox sendmail \
 -H"exec /system/sdcard/bin/openssl s_client -quiet -connect $SERVER:$PORT -tls1 -starttls smtp" \


### PR DESCRIPTION
Message header was missing date field.
UUENCODE is not widely supported by mail clients and would not allow the attachment to decode on many platforms. Replaced with base64.
Filename was the same with every event causing name collisions. Changed to yyyymmddhhmmss-#.jpg format.