### PR TITLE
remove unused configuration and add rtsmp auth example

### DIFF
--- a/firmware_mod/config/rtspserver.conf.dist
+++ b/firmware_mod/config/rtspserver.conf.dist
@@ -9,9 +9,13 @@
 # H264 RTSP server options
 # Examples:
 # RTSPH264OPTS="-S -W960 -H540"
+# To enable authentication:
+# RTSPH264OPTS="-U user:password"
 RTSPH264OPTS=""
 
 # MJPEG RTSP server options
 # Examples:
 # RTSPMJPEGOPTS="-W960 -H540"
+# To enable authentication:
+# RTSPMJPEGOPTS="-U user:password"
 RTSPMJPEGOPTS=""

--- a/firmware_mod/config/v4l2rtspserver.conf
+++ b/firmware_mod/config/v4l2rtspserver.conf
@@ -1,1 +1,0 @@
--U user1:password2

--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -3,9 +3,6 @@ PIDFILE="/run/v4l2rtspserver-master-h264.pid"
 CONFIGPATH="/system/sdcard/config"
 export LD_LIBRARY_PATH='/thirdlib:/system/lib'
 
-#read v4l2config (username, password)
-v4l2config=$(cat /system/sdcard/config/v4l2rtspserver.conf)
-
 if [ -f /system/sdcard/config/rtspserver.conf ]; then
   source /system/sdcard/config/rtspserver.conf
 fi
@@ -30,8 +27,7 @@ start()
   else
     echo "Starting v4l2rtspserver-master"
     /system/sdcard/controlscripts/rtsp-mjpeg stop
-    # We no longer start v4l2rtspserver-master in run.sh
-    #killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
+
     ## Configure OSD
     if [ -f /system/sdcard/controlscripts/configureOsd ]; then
       source /system/sdcard/controlscripts/configureOsd  2>/dev/null

--- a/firmware_mod/controlscripts/rtsp-mjpeg
+++ b/firmware_mod/controlscripts/rtsp-mjpeg
@@ -6,9 +6,6 @@ if [ -f /system/sdcard/config/rtspserver.conf ]; then
   source /system/sdcard/config/rtspserver.conf
 fi
 
-#read v4l2config (username, password)
-v4l2config=$(cat /system/sdcard/config/v4l2rtspserver.conf)
-
 if [ -f /system/sdcard/config/osd ]; then
   source /system/sdcard/config/osd 2>/dev/null
 fi
@@ -29,8 +26,7 @@ start()
   else
     echo "Starting v4l2rtspserver-master with parameter -fMJPG"
     /system/sdcard/controlscripts/rtsp-h264 stop
-    # We no longer start v4l2rtspserver-master in run.sh
-    #killall v4l2rtspserver-master # As the run.sh starts a v4l2rtspserver as well
+
     ## Configure OSD
     if [ -f /system/sdcard/controlscripts/configureOsd ]; then
       source /system/sdcard/controlscripts/configureOsd  2>/dev/null


### PR DESCRIPTION
It seems like since this commit https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/commit/34f36bf7710d546336e7ae38bf48d0bab16ff1ac the `v4l2config` variable in the rtsp command scripts is not used anymore.

I've removed the `v4l2config` parts and added an example to the rtspserver.conf.dist which is now used for configuration.