### PR TITLE
Motion config restore

### DIFF
--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -252,11 +252,11 @@ if [ -n "$F_cmd" ]; then
         if [ -f /system/sdcard/config/motion.conf ]; then
             source /system/sdcard/config/motion.conf
         fi
-        if [ ${motion_sensitivity} = -1 ]; then
+        if [ ${motion_sensitivity} -eq -1 ]; then
              motion_sensitivity=4
         fi
         /system/sdcard/bin/setconf -k m -v ${motion_sensitivity}
-        rewrite_config /system/sdcard/config/motion.conf motion_sensitivity 4
+        rewrite_config /system/sdcard/config/motion.conf motion_sensitivity "${motion_sensitivity}"
     ;;
 
     motion_detection_off)

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -252,11 +252,11 @@ if [ -n "$F_cmd" ]; then
         if [ -f /system/sdcard/config/motion.conf ]; then
             source /system/sdcard/config/motion.conf
         fi
-        if [ ${motion_sensitivity} -eq -1 ]; then
+        if [ $motion_sensitivity -eq -1 ]; then
              motion_sensitivity=4
         fi
-        /system/sdcard/bin/setconf -k m -v ${motion_sensitivity}
-        rewrite_config /system/sdcard/config/motion.conf motion_sensitivity "${motion_sensitivity}"
+        /system/sdcard/bin/setconf -k m -v $motion_sensitivity
+        rewrite_config /system/sdcard/config/motion.conf motion_sensitivity $motion_sensitivity
     ;;
 
     motion_detection_off)

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -248,7 +248,15 @@ if [ -n "$F_cmd" ]; then
     ;;
 
     motion_detection_on)
-      /system/sdcard/bin/setconf -k m -v 4
+        motion_sensitivity=4
+        if [ -f /system/sdcard/config/motion.conf ]; then
+            source /system/sdcard/config/motion.conf
+        fi
+        if [ ${motion_sensitivity} = -1 ]; then
+             motion_sensitivity=4
+        fi
+        /system/sdcard/bin/setconf -k m -v ${motion_sensitivity}
+        rewrite_config /system/sdcard/config/motion.conf motion_sensitivity 4
     ;;
 
     motion_detection_off)


### PR DESCRIPTION
When usong action.cgi command motion_on, re-read the conf file to restore sensitivity
See issue #290 https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/issues/290