### PR TITLE
Always checkout .sh and .dist with UNIX line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.conf.dist text eol=lf


### PR DESCRIPTION
Ref #291 Always checkout `.sh` and `.conf.dist` with unix line endings

This should help resolve issues when cloning on windows.