### PR TITLE
use relative paths for web interface.

### DIFF
--- a/firmware_mod/www/cgi-bin/scripts.cgi
+++ b/firmware_mod/www/cgi-bin/scripts.cgi
@@ -99,18 +99,18 @@ else
       # Start / Stop / Run buttons
       echo "<div class='buttons'>"
       if grep -q "^start()" "$SCRIPT_HOME/$i"; then
-        echo "<button data-target='/cgi-bin/scripts.cgi?cmd=start&script=$i' class='button is-link script_action_start' data-script='$i' "
+        echo "<button data-target='cgi-bin/scripts.cgi?cmd=start&script=$i' class='button is-link script_action_start' data-script='$i' "
         if [ ! -z "$status" ]; then
           echo "disabled"
         fi
         echo ">Start</button>"
       else
-        echo "<button data-target='/cgi-bin/scripts.cgi?cmd=start&script=$i' class='button is-link script_action_start' data-script='$i' "
+        echo "<button data-target='cgi-bin/scripts.cgi?cmd=start&script=$i' class='button is-link script_action_start' data-script='$i' "
         echo ">Run</button>"
       fi
 
       if grep -q "^stop()" "$SCRIPT_HOME/$i"; then
-        echo "<button data-target='/cgi-bin/scripts.cgi?cmd=stop&script=$i' class='button is-danger script_action_stop' data-script='$i' "
+        echo "<button data-target='cgi-bin/scripts.cgi?cmd=stop&script=$i' class='button is-danger script_action_stop' data-script='$i' "
         if [ ! -n "$status" ]; then
           echo "disabled"
         fi
@@ -122,8 +122,8 @@ else
       # Autostart Switch
       echo "<span class='card-footer-item'>"
       echo "<input type='checkbox' id='autorun_$i' name='autorun_$i' class='switch is-rtl autostart' data-script='$i' "
-        echo " data-unchecked='/cgi-bin/scripts.cgi?cmd=disable&script=$i'"
-        echo " data-checked='/cgi-bin/scripts.cgi?cmd=enable&script=$i'"
+        echo " data-unchecked='cgi-bin/scripts.cgi?cmd=disable&script=$i'"
+        echo " data-checked='cgi-bin/scripts.cgi?cmd=enable&script=$i'"
       if [ -f "/system/sdcard/config/autostart/$i" ]; then
         echo " checked='checked'"
       fi
@@ -132,7 +132,7 @@ else
       echo "</span>"
 
       # View link
-      echo "<a href='/cgi-bin/scripts.cgi?cmd=view&script=$i' class='card-footer-item view_script' data-script="$i">View</a>"
+      echo "<a href='cgi-bin/scripts.cgi?cmd=view&script=$i' class='card-footer-item view_script' data-script="$i">View</a>"
       echo "</footer>"
     fi
     # Card - End

--- a/firmware_mod/www/cgi-bin/status.cgi
+++ b/firmware_mod/www/cgi-bin/status.cgi
@@ -12,7 +12,7 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>System</p></header>
     <div class='card-content'>
-    <form id="tzForm" action="/cgi-bin/action.cgi?cmd=settz" method="post">
+    <form id="tzForm" action="cgi-bin/action.cgi?cmd=settz" method="post">
 
         <div class="field is-horizontal">
             <div class="field-label is-normal">
@@ -89,16 +89,16 @@ cat << EOF
         <div class="column">
             <label>Blue LED</label>
             <div class="buttons">
-                <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=blue_led_on')">On</button>
-                <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=blue_led_off')">Off</button>
+                <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=blue_led_on')">On</button>
+                <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=blue_led_off')">Off</button>
             </div>
         </div>
 
         <div class="column">
             <label>Yellow LED</label>
             <div class="buttons">
-                <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=yellow_led_on')">On</button>
-                <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=yellow_led_off')">Off</button>
+                <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=yellow_led_on')">On</button>
+                <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=yellow_led_off')">Off</button>
             </div>
         </div>
 
@@ -114,16 +114,16 @@ cat << EOF
         <div class="column">
             <label>IR LED</label>
             <div class="buttons">
-            <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=ir_led_on')">On</button>
-            <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=ir_led_off')">Off</button>
+            <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=ir_led_on')">On</button>
+            <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=ir_led_off')">Off</button>
             </div>
         </div>
 
         <div class="column">
             <label>IR Cut</label>
             <div class="buttons">
-            <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=ir_cut_on')">On</button>
-            <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=ir_cut_off')">Off</button>
+            <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=ir_cut_on')">On</button>
+            <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=ir_cut_off')">Off</button>
             </div>
         </div>
         </div>
@@ -136,11 +136,11 @@ cat << EOF
     <div class='card-content'>
         <div class="columns">
         <div class="column">
-            <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=auto_night_mode_start')">On</button>
-            <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=auto_night_mode_stop')">Off</button>
+            <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=auto_night_mode_start')">On</button>
+            <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=auto_night_mode_stop')">Off</button>
         </div>
         <div class="column">
-        <form id="formldr" action="/cgi-bin/action.cgi?cmd=setldravg" method="post">
+        <form id="formldr" action="cgi-bin/action.cgi?cmd=setldravg" method="post">
             <p>Use average measurement on switching.</p>
             <label class="label">Number of measurements</label>
             <div class="field is-grouped">
@@ -176,16 +176,16 @@ cat << EOF
         <div class="column">
             <label>Night Vision</label>
             <div class="buttons">
-            <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=toggle-rtsp-nightvision-on')">On</button>
-            <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=toggle-rtsp-nightvision-off')">Off</button>
+            <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=toggle-rtsp-nightvision-on')">On</button>
+            <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=toggle-rtsp-nightvision-off')">Off</button>
             </div>
         </div>
 
         <div class="column">
             <label>Flip</label>
             <div class="buttons">
-            <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=flip-on')">On</button>
-            <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=flip-off')">Off</button>
+            <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=flip-on')">On</button>
+            <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=flip-off')">Off</button>
             </div>
         </div>
 
@@ -201,32 +201,32 @@ cat << EOF
             <tr>
                 <td></td>
                 <td>
-                    <button class="button is-link" onclick="call('/cgi-bin/action.cgi?cmd=motor_up&val='+document.getElementById('val').value)">&uarr; Up</button>
+                    <button class="button is-link" onclick="call('cgi-bin/action.cgi?cmd=motor_up&val='+document.getElementById('val').value)">&uarr; Up</button>
                 </td>
                 <td></td>
             </tr>
             <tr>
                 <td>
-                    <button class="button is-link" onclick="call('/cgi-bin/action.cgi?cmd=motor_left&val='+document.getElementById('val').value)">&larr; Left</button>
+                    <button class="button is-link" onclick="call('cgi-bin/action.cgi?cmd=motor_left&val='+document.getElementById('val').value)">&larr; Left</button>
                 </td>
                 <td>
                     <input class="input has-text-centered" type="text" id="val" name="val" value="100">
                 </td>
                 <td>
-                    <button class="button is-link" onclick="call('/cgi-bin/action.cgi?cmd=motor_right&val='+document.getElementById('val').value)">Right &rarr;</button>
+                    <button class="button is-link" onclick="call('cgi-bin/action.cgi?cmd=motor_right&val='+document.getElementById('val').value)">Right &rarr;</button>
                 </td>
             </tr>
             <tr>
                 <td></td>
                 <td>
-                    <button class="button is-link" onclick="call('/cgi-bin/action.cgi?cmd=motor_down&val='+document.getElementById('val').value)">&darr; Down</button>
+                    <button class="button is-link" onclick="call('cgi-bin/action.cgi?cmd=motor_down&val='+document.getElementById('val').value)">&darr; Down</button>
                 </td>
                 <td></td>
             </tr>
         </table>
         <div class="buttons">
-        <button class="button is-warning" onclick="call('/cgi-bin/action.cgi?cmd=motor_vcalibrate')">Calibrate Vertical</button>
-        <button class="button is-warning" onclick="call('/cgi-bin/action.cgi?cmd=motor_hcalibrate')">Calibrate Horizontal</button>
+        <button class="button is-warning" onclick="call('cgi-bin/action.cgi?cmd=motor_vcalibrate')">Calibrate Vertical</button>
+        <button class="button is-warning" onclick="call('cgi-bin/action.cgi?cmd=motor_hcalibrate')">Calibrate Horizontal</button>
         </div>
     </div>
 </div>
@@ -241,14 +241,14 @@ cat << EOF
         <div class="column">
         <label>Audio Test</label>
         <div class="buttons">
-        <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=audio_test')">Test</button>
+        <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=audio_test')">Test</button>
         </div>
         </div>
 
         <div class="column">
         <label>Image</label>
         <div class="buttons">
-        <a class="button is-link" href='/cgi-bin/currentpic.cgi' target='_blank'>Get</a>
+        <a class="button is-link" href='cgi-bin/currentpic.cgi' target='_blank'>Get</a>
         </div>
         </div>
 
@@ -261,7 +261,7 @@ cat << EOF
     <header class='card-header'><p class='card-header-title'>Resolution</p></header>
     <div class='card-content'>
 
-        <form id="formResolution" action="/cgi-bin/action.cgi?cmd=set_video_size" method="post">
+        <form id="formResolution" action="cgi-bin/action.cgi?cmd=set_video_size" method="post">
         <div class="field is-horizontal">
             <div class="field-label is-normal">
                 <label class="label">Video Size</label>
@@ -301,8 +301,8 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>Start H264 RTSP</p></header>
     <div class='card-content'>
-        <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=h264_start')">Start</button>
-        <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=rtsp_stop')">Stop</button>
+        <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=h264_start')">Start</button>
+        <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=rtsp_stop')">Stop</button>
 EOF
 
 PATH="/bin:/sbin:/usr/bin:/media/mmcblk0p2/data/bin:/media/mmcblk0p2/data/sbin:/media/mmcblk0p2/data/usr/bin"
@@ -320,8 +320,8 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>Start MJGEP RTSP</p></header>
     <div class='card-content'>
-        <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=mjpeg_start')">Start</button>
-        <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=rtsp_stop')">Stop</button>
+        <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=mjpeg_start')">Start</button>
+        <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=rtsp_stop')">Stop</button>
 EOF
 
 PATH="/bin:/sbin:/usr/bin:/media/mmcblk0p2/data/bin:/media/mmcblk0p2/data/sbin:/media/mmcblk0p2/data/usr/bin"
@@ -337,7 +337,7 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>OSD Display</p></header>
     <div class='card-content'>
-        <form id="formOSD" action="/cgi-bin/action.cgi?cmd=osd" method="post">
+        <form id="formOSD" action="cgi-bin/action.cgi?cmd=osd" method="post">
 
             <div class="field is-horizontal">
                 <div class="field-label is-normal">
@@ -460,8 +460,8 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>Display debug info on OSD</p></header>
     <div class='card-content'>
-        <button class="button is-link" onClick="call('/cgi-bin/action.cgi?cmd=onDebug')">On</button>
-        <button class="button is-warning" onClick="call('/cgi-bin/action.cgi?cmd=offDebug')">Off</button>
+        <button class="button is-link" onClick="call('cgi-bin/action.cgi?cmd=onDebug')">On</button>
+        <button class="button is-warning" onClick="call('cgi-bin/action.cgi?cmd=offDebug')">Off</button>
     </div>
 </div>
 
@@ -469,7 +469,7 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>Timelapse</p></header>
     <div class='card-content'>
-        <form id="formTimelapse" action="/cgi-bin/action.cgi?cmd=conf_timelapse" method="post">
+        <form id="formTimelapse" action="cgi-bin/action.cgi?cmd=conf_timelapse" method="post">
         <div class="field is-horizontal">
             <div class="field-label is-normal">
                 <label class="label">Interval</label>
@@ -515,7 +515,7 @@ cat << EOF
 <div class='card status_card'>
     <header class='card-header'><p class='card-header-title'>Start original Xiaomi Software</p></header>
     <div class='card-content'>
-        <button class="button" onClick="call('/cgi-bin/action.cgi?cmd=xiaomi_start')">Start</button>
+        <button class="button" onClick="call('cgi-bin/action.cgi?cmd=xiaomi_start')">Start</button>
     </div>
 </div>
 

--- a/firmware_mod/www/configmotion.html
+++ b/firmware_mod/www/configmotion.html
@@ -5,14 +5,14 @@
 </p>
 
 <div id="motion_img_container" style="margin: 1em 0; position:relative;">
-    <img id="motion_picture" src="/cgi-bin/currentpic.cgi" />
+    <img id="motion_picture" src="cgi-bin/currentpic.cgi" />
     <span id="region_disabled" class="has-text-danger is-size-1" style="display: none; position: absolute; top: 10%; left: 30%; padding: 0.25em 0.5em; background-color: rgba(20, 20, 20, 0.5); border-radius: 0.25em;">
         Region disabled
     </span>
 </div>
 
 <div class="column is-two-thirds">
-    <form id="confMotionForm" action="/cgi-bin/action.cgi?cmd=set_region_of_interest" method="post">
+    <form id="confMotionForm" action="cgi-bin/action.cgi?cmd=set_region_of_interest" method="post">
         <input id="x0" name="x0" type="hidden" />
         <input id="y0" name="y0" type="hidden" />
         <input id="x1" name="x1" type="hidden" />

--- a/firmware_mod/www/index.html
+++ b/firmware_mod/www/index.html
@@ -155,7 +155,7 @@
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
         <div class="container">
             <div class="navbar-brand">
-                <a class="navbar-item" href="/">Dafang Hacks</a>
+                <a class="navbar-item" href=".">Dafang Hacks</a>
                 <a id="navbar_burger" role="button" class="navbar-burger" data-target="nav_menu" aria-label="menu" aria-expanded="false">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -168,13 +168,13 @@
                     <div class="navbar-item has-dropdown is-hoverable">
                         <span class="navbar-link">Manage</span>
                         <div class="navbar-dropdown is-boxed">
-                            <a id="status" class="navbar-item onpage" href="javascript: void(0)" data-target="/cgi-bin/status.cgi">Settings</a>
-                            <a id="scripts" class="navbar-item onpage" href="javascript: void(0)" data-target="/cgi-bin/scripts.cgi">Services</a>
-                            <a id="configmotion" class="navbar-item onpage" href="javascript: void(0)" data-target="/configmotion.html">Motion Detection</a>
-                            <a id="network" class="navbar-item onpage" href="javascript: void(0)" data-target="/cgi-bin/network.cgi">Network Information</a>
-                            <a id="logs" class="navbar-item onpage" href="javascript: void(0)" data-target="/logs.html">Logs</a>
-                            <a class="navbar-item prompt" href="javascript: void(0)" data-message="Are you sure you wish to reboot?" data-target="/cgi-bin/action.cgi?cmd=reboot">Reboot</a>
-                            <a class="navbar-item prompt" href="javascript: void(0)" data-message="Are you sure you wish to shutdown?" data-target="/cgi-bin/action.cgi?cmd=shutdown">Shutdown</a>
+                            <a id="status" class="navbar-item onpage" href="javascript: void(0)" data-target="cgi-bin/status.cgi">Settings</a>
+                            <a id="scripts" class="navbar-item onpage" href="javascript: void(0)" data-target="cgi-bin/scripts.cgi">Services</a>
+                            <a id="configmotion" class="navbar-item onpage" href="javascript: void(0)" data-target="configmotion.html">Motion Detection</a>
+                            <a id="network" class="navbar-item onpage" href="javascript: void(0)" data-target="cgi-bin/network.cgi">Network Information</a>
+                            <a id="logs" class="navbar-item onpage" href="javascript: void(0)" data-target="logs.html">Logs</a>
+                            <a class="navbar-item prompt" href="javascript: void(0)" data-message="Are you sure you wish to reboot?" data-target="cgi-bin/action.cgi?cmd=reboot">Reboot</a>
+                            <a class="navbar-item prompt" href="javascript: void(0)" data-message="Are you sure you wish to shutdown?" data-target="cgi-bin/action.cgi?cmd=shutdown">Shutdown</a>
                         </div>
                     </div>
                 </div>
@@ -186,65 +186,65 @@
                         <div class="navbar-dropdown is-boxed is-right">
                             <!-- Led: IR -->
                             <span class="navbar-item">
-                                <input id="ir_led" type="checkbox" name="ir_led" class="switch" data-checked="/cgi-bin/action.cgi?cmd=ir_led_on" data-unchecked="/cgi-bin/action.cgi?cmd=ir_led_off">
+                                <input id="ir_led" type="checkbox" name="ir_led" class="switch" data-checked="cgi-bin/action.cgi?cmd=ir_led_on" data-unchecked="cgi-bin/action.cgi?cmd=ir_led_off">
                                 <label for="ir_led">IR Led</label>
                             </span>
                             <!-- IR Cut -->
                             <span class="navbar-item">
-                                <input id="ir_cut" type="checkbox" name="ir_cut" class="switch" data-checked="/cgi-bin/action.cgi?cmd=ir_cut_on" data-unchecked="/cgi-bin/action.cgi?cmd=ir_cut_off">
+                                <input id="ir_cut" type="checkbox" name="ir_cut" class="switch" data-checked="cgi-bin/action.cgi?cmd=ir_cut_on" data-unchecked="cgi-bin/action.cgi?cmd=ir_cut_off">
                                 <label for="ir_cut">IR-Cut</label>
                             </span>
                             <!-- Auto Night Detect -->
                             <span class="navbar-item">
-                                <input id="auto_night_detection" type="checkbox" name="auto_night_detection" class="switch" data-checked="/cgi-bin/scripts.cgi?cmd=start&script=auto-night-detection"
-                                    data-unchecked="/cgi-bin/scripts.cgi?cmd=stop&script=auto-night-detection">
+                                <input id="auto_night_detection" type="checkbox" name="auto_night_detection" class="switch" data-checked="cgi-bin/scripts.cgi?cmd=start&script=auto-night-detection"
+                                    data-unchecked="cgi-bin/scripts.cgi?cmd=stop&script=auto-night-detection">
                                 <label for="auto_night_detection">Auto Night Detection</label>
                             </span>
                             <!-- LED: Blue -->
                             <span class="navbar-item">
-                                <input id="blue_led" type="checkbox" name="blue_led" class="switch" data-checked="/cgi-bin/action.cgi?cmd=blue_led_on" data-unchecked="/cgi-bin/action.cgi?cmd=blue_led_off">
+                                <input id="blue_led" type="checkbox" name="blue_led" class="switch" data-checked="cgi-bin/action.cgi?cmd=blue_led_on" data-unchecked="cgi-bin/action.cgi?cmd=blue_led_off">
                                 <label for="blue_led">Blue LED</label>
                             </span>
                             <!-- LED: Yellow -->
                             <span class="navbar-item">
-                                <input id="yellow_led" type="checkbox" name="yellow_led" class="switch" data-checked="/cgi-bin/action.cgi?cmd=yellow_led_on"
-                                    data-unchecked="/cgi-bin/action.cgi?cmd=yellow_led_off">
+                                <input id="yellow_led" type="checkbox" name="yellow_led" class="switch" data-checked="cgi-bin/action.cgi?cmd=yellow_led_on"
+                                    data-unchecked="cgi-bin/action.cgi?cmd=yellow_led_off">
                                 <label for="yellow_led">Yellow LED</label>
                             </span>
                             <!-- Motion Detection -->
                             <span class="navbar-item">
-                                <input id="motion_detection" type="checkbox" name="motion_detection" class="switch" data-checked="/cgi-bin/action.cgi?cmd=motion_detection_on"
-                                    data-unchecked="/cgi-bin/action.cgi?cmd=motion_detection_off">
+                                <input id="motion_detection" type="checkbox" name="motion_detection" class="switch" data-checked="cgi-bin/action.cgi?cmd=motion_detection_on"
+                                    data-unchecked="cgi-bin/action.cgi?cmd=motion_detection_off">
                                 <label for="motion_detection">Motion Detection</label>
                             </span>
                             <!-- RTSP H264 -->
                             <span class="navbar-item">
-                                <input id="rtsp_h264" type="checkbox" name="rtsp_h264" class="switch" data-checked="/cgi-bin/scripts.cgi?cmd=start&script=rtsp-h264"
-                                    data-unchecked="/cgi-bin/scripts.cgi?cmd=stop&script=rtsp-h264">
+                                <input id="rtsp_h264" type="checkbox" name="rtsp_h264" class="switch" data-checked="cgi-bin/scripts.cgi?cmd=start&script=rtsp-h264"
+                                    data-unchecked="cgi-bin/scripts.cgi?cmd=stop&script=rtsp-h264">
                                 <label for="rtsp_h264">RTSP H264 Server</label>
                             </span>
                             <!-- RTSP MJPEG -->
                             <span class="navbar-item">
-                                <input id="rtsp_mjpeg" type="checkbox" name="rtsp_mjpeg" class="switch" data-checked="/cgi-bin/scripts.cgi?cmd=start&script=rtsp-mjpeg"
-                                    data-unchecked="/cgi-bin/scripts.cgi?cmd=stop&script=rtsp-mjpeg">
+                                <input id="rtsp_mjpeg" type="checkbox" name="rtsp_mjpeg" class="switch" data-checked="cgi-bin/scripts.cgi?cmd=start&script=rtsp-mjpeg"
+                                    data-unchecked="cgi-bin/scripts.cgi?cmd=stop&script=rtsp-mjpeg">
                                 <label for="rtsp_mjpeg">RTSP MJPEG Server</label>
                             </span>
                             <!-- MQTT Status -->
                             <span class="navbar-item">
-                                <input id="mqtt_control" type="checkbox" name="mqtt_control" class="switch" data-checked="/cgi-bin/scripts.cgi?cmd=start&script=mqtt-status"
-                                    data-unchecked="/cgi-bin/scripts.cgi?cmd=stop&script=mqtt-status">
+                                <input id="mqtt_control" type="checkbox" name="mqtt_control" class="switch" data-checked="cgi-bin/scripts.cgi?cmd=start&script=mqtt-status"
+                                    data-unchecked="cgi-bin/scripts.cgi?cmd=stop&script=mqtt-status">
                                 <label for="mqtt_control">MQTT Status Server</label>
                             </span>
                             <!-- MQTT Control -->
                             <span class="navbar-item">
-                                <input id="mqtt_status" type="checkbox" name="mqtt_status" class="switch" data-checked="/cgi-bin/scripts.cgi?cmd=start&script=mqtt-control"
-                                    data-unchecked="/cgi-bin/scripts.cgi?cmd=stop&script=mqtt-control">
+                                <input id="mqtt_status" type="checkbox" name="mqtt_status" class="switch" data-checked="cgi-bin/scripts.cgi?cmd=start&script=mqtt-control"
+                                    data-unchecked="cgi-bin/scripts.cgi?cmd=stop&script=mqtt-control">
                                 <label for="mqtt_status">MQTT Control Server</label>
                             </span>
                             <!-- Startup Sound -->
                             <span class="navbar-item">
-                                <input id="sound_on_startup" type="checkbox" name="sound_on_startup" class="switch" data-checked="/cgi-bin/scripts.cgi?cmd=start&script=sound-on-startup"
-                                    data-unchecked="/cgi-bin/scripts.cgi?cmd=stop&script=sound-on-startup">
+                                <input id="sound_on_startup" type="checkbox" name="sound_on_startup" class="switch" data-checked="cgi-bin/scripts.cgi?cmd=start&script=sound-on-startup"
+                                    data-unchecked="cgi-bin/scripts.cgi?cmd=stop&script=sound-on-startup">
                                 <label for="sound_on_startup">Sound on Startup</label>
                             </span>
                         </div>
@@ -256,7 +256,7 @@
 
     <section id="main" class="section">
         <div id="content" class="container">
-            <img id="liveview" src="/cgi-bin/currentpic.cgi" onerror="this.src='css/unable_load.png';">
+            <img id="liveview" src="cgi-bin/currentpic.cgi" onerror="this.src='css/unable_load.png';">
             <div id="dpad_container">
                 <div id="dpad">
                     <div class="dpad_button up">

--- a/firmware_mod/www/logs.html
+++ b/firmware_mod/www/logs.html
@@ -57,7 +57,7 @@ $(document).ready(function() {
 
         // get motion config info
         $.ajax({
-            'url': '/cgi-bin/action.cgi?cmd=showlog',
+            'url': 'cgi-bin/action.cgi?cmd=showlog',
         }).done(function (log) {
             $('#tab1').html(log);
 
@@ -66,7 +66,7 @@ $(document).ready(function() {
             var str="logname=" + tab
             console.log(str);
           $.ajax({
-            'url': '/cgi-bin/action.cgi?cmd=showlog',
+            'url': 'cgi-bin/action.cgi?cmd=showlog',
             'type' : 'POST',
             'data' : str
             //logname=$('#tab-content p').id

--- a/firmware_mod/www/scripts/index.html.js
+++ b/firmware_mod/www/scripts/index.html.js
@@ -8,7 +8,7 @@ var timeoutJobs = {};
 
 function refreshLiveImage() {
     var ts = new Date().getTime();
-    $("#liveview").attr("src", "/cgi-bin/currentpic.cgi?" + ts);
+    $("#liveview").attr("src", "cgi-bin/currentpic.cgi?" + ts);
 }
 function scheduleRefreshLiveImage(interval) {
     if (timeoutJobs['refreshLiveImage'] != undefined) {
@@ -19,7 +19,7 @@ function scheduleRefreshLiveImage(interval) {
 function syncSwitch(sw) {
     var e = $('#' + sw);
     if (!e.prop('disabled')) {
-        $.get("/cgi-bin/state.cgi", {
+        $.get("cgi-bin/state.cgi", {
             cmd: sw
         }).done(function (status) {
             // console.log(sw + " status " + status + " / current " + e.prop('checked'));
@@ -81,7 +81,7 @@ $(document).ready(function () {
     // Camera controls
     $(".cam_button").click(function () {
         var b = $(this);
-        $.get("/cgi-bin/action.cgi?cmd=" + b.data('cmd')).done(function (data) {
+        $.get("cgi-bin/action.cgi?cmd=" + b.data('cmd')).done(function (data) {
             setTimeout(refreshLiveImage, 500);
         });
     });
@@ -90,7 +90,7 @@ $(document).ready(function () {
     $(".switch").click(function () {
         var e = $(this);
         e.prop('disabled', true);
-        $.get("/cgi-bin/state.cgi", {
+        $.get("cgi-bin/state.cgi", {
             cmd: e.attr('id')
         }).done(function (status) {
             if (status.trim().toLowerCase() == "on") {

--- a/firmware_mod/www/scripts/scripts.cgi.js
+++ b/firmware_mod/www/scripts/scripts.cgi.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
             e.addClass("is-loading");
             $.get(e.data("target")).done(function (res) {
                 $("#show_" + e.data("script")).html(res);
-                $("#content").load("/cgi-bin/scripts.cgi");
+                $("#content").load("cgi-bin/scripts.cgi");
             });
         }
         return false;
@@ -20,7 +20,7 @@ $(document).ready(function () {
             e.addClass("is-loading");
             $.get(e.data("target")).done(function (res) {
                 $("#show_" + e.data("script")).html(res);
-                $("#content").load("/cgi-bin/scripts.cgi");
+                $("#content").load("cgi-bin/scripts.cgi");
             });
         }
         return false;

--- a/firmware_mod/www/scripts/status.cgi.js
+++ b/firmware_mod/www/scripts/status.cgi.js
@@ -21,7 +21,7 @@ $(document).ready(function () {
 
             showResult(res);
             // reload after 2s
-            setTimeout(function () { $('#content').load('/cgi-bin/status.cgi'); }, 2000);
+            setTimeout(function () { $('#content').load('cgi-bin/status.cgi'); }, 2000);
         });
         event.preventDefault();
     });


### PR DESCRIPTION
Updated the web interface to use relative paths, rather than (hardcoded) absolute paths.

This is useful if you want to run your camera(s) behind a reverse-proxy, setting it up like "myserver.com/cam1", "myserver.com/cam2", and so on.

Since the html isn't generated dynamically, I think that's the most straightforward way to achieve this, without breaking the normal usecase.