### PR TITLE
only toggle gpio for ircut, keep state in tmp file

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -111,18 +111,24 @@ ir_cut(){
   on)
     setgpio 25 0
     setgpio 26 1
+    sleep 1
+    setgpio 26 0
+    echo "1" > /var/run/ircut
     ;;
   off)
-    setgpio 25 1
     setgpio 26 0
+    setgpio 25 1
+    sleep 1
+    setgpio 25 0
+    echo "0" > /var/run/ircut
     ;;
   status)
-    status=$(getgpio 25)
+    status=$(cat /var/run/ircut)
     case $status in
-      0)
+      1)
         echo "ON"
         ;;
-      1)
+      0)
         echo "OFF"
       ;;
     esac

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -79,11 +79,17 @@ if [ -n "$F_cmd" ]; then
     ir_cut_on)
       setgpio 25 0
       setgpio 26 1
+      sleep 1
+      setgpio 26 0
+      echo "1" > /var/run/ircut
     ;;
 
     ir_cut_off)
-      setgpio 25 1
       setgpio 26 0
+      setgpio 25 1
+      sleep 1
+      setgpio 25 0
+      echo "0" > /var/run/ircut
     ;;
 
     motor_left)


### PR DESCRIPTION
As mentioned while investigating/discussing issue #249 there is also a problem with the gpio of ircut staying active.

This PR changes this into a toggle, the gpio is back to zero after toggling.

An additional problem is that the state was using the gpio state, this has been changed by using a temp file containing 0 or 1, it is written in /var/run/ircut  (better locations welcome)