### PR TITLE
Remove quotes around options or v4l2rtspserver-master does not start

### DIFF
--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -42,7 +42,7 @@ start()
     if [ -f /system/sdcard/controlscripts/configureMotion ]; then
       . /system/sdcard/controlscripts/configureMotion  2>/dev/null
     fi
-    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master "$RTSPH264OPTS" >> "$LOGPATH" &
+    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master $RTSPH264OPTS >> "$LOGPATH" &
     echo "$!" > "$PIDFILE"
   fi
 }


### PR DESCRIPTION
Ref #337, remove quotes or v4l2rtspserver-master does not start on boot or via the UI.