### PR TITLE
Remove quotes around options for v4l2rtspserver

### DIFF
--- a/firmware_mod/controlscripts/rtsp-mjpeg
+++ b/firmware_mod/controlscripts/rtsp-mjpeg
@@ -42,7 +42,7 @@ start()
     if [ -f /system/sdcard/controlscripts/configureMotion ]; then
       . /system/sdcard/controlscripts/configureMotion  2>/dev/null
     fi
-    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG "$RTSPMJPEGOPTS"  >> "$LOGPATH" &
+    /system/sdcard/bin/busybox nohup /system/sdcard/bin/v4l2rtspserver-master -fMJPG $RTSPMJPEGOPTS  >> "$LOGPATH" &
     echo "$!" > "$PIDFILE"
   fi
 }


### PR DESCRIPTION
(same as d59e31d775170220b5af7c0938425adec2c5132b but for rtsp-mjpeg)