### PR TITLE
Fix greenish video color #344 and version display

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -27,7 +27,7 @@ if [ ! -d /system/sdcard/etc ]; then
   mkdir /system/sdcard/etc
   cp -fRL /etc/TZ /etc/protocols /etc/fstab /etc/inittab /etc/hosts \
     /etc/passwd /etc/shadow /etc/group /etc/resolv.conf /etc/hostname \
-    /etc/profile /etc/sensor /system/sdcard/etc
+    /etc/profile /etc/os-release /etc/sensor /system/sdcard/etc
   sed -i s#/:#/root:# /system/sdcard/etc/passwd
   echo "Created etc directory on sdcard" >> $LOGPATH
 fi

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -25,9 +25,9 @@ if [ ! -d /system/sdcard/root ]; then
 fi
 if [ ! -d /system/sdcard/etc ]; then
   mkdir /system/sdcard/etc
-  cp -f /etc/TZ /etc/protocols /etc/fstab /etc/inittab /etc/hosts \
+  cp -frL /etc/TZ /etc/protocols /etc/fstab /etc/inittab /etc/hosts \
     /etc/passwd /etc/shadow /etc/group /etc/resolv.conf /etc/hostname \
-    /etc/profile /system/sdcard/etc
+    /etc/profile /etc/sensor /system/sdcard/etc
   sed -i s#/:#/root:# /system/sdcard/etc/passwd
   echo "Created etc directory on sdcard" >> $LOGPATH
 fi

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -25,7 +25,7 @@ if [ ! -d /system/sdcard/root ]; then
 fi
 if [ ! -d /system/sdcard/etc ]; then
   mkdir /system/sdcard/etc
-  cp -frL /etc/TZ /etc/protocols /etc/fstab /etc/inittab /etc/hosts \
+  cp -fRL /etc/TZ /etc/protocols /etc/fstab /etc/inittab /etc/hosts \
     /etc/passwd /etc/shadow /etc/group /etc/resolv.conf /etc/hostname \
     /etc/profile /etc/sensor /system/sdcard/etc
   sed -i s#/:#/root:# /system/sdcard/etc/passwd


### PR DESCRIPTION
Some files were missing after 3d50d0e0aac6356a8b4275376cfdafa5f78f88b4

Camera needs the files from /etc/sensor.
Copying the content since symlinks don't seem to work on FAT32

Also copying /etc/os-release to make the version display work again.