### PR TITLE
Add compression and day folder to timelapse

### DIFF
--- a/firmware_mod/config/timelapse.conf
+++ b/firmware_mod/config/timelapse.conf
@@ -2,3 +2,7 @@
 TIMELAPSE_INTERVAL=2.0
 # Duration of the script should run, in minutes, set to 0 for unlimited
 TIMELAPSE_DURATION=0
+# Save dir config
+SAVE_DIR_PER_DAY=1
+# Enable compression
+COMPRESSION_QUALITY=80

--- a/firmware_mod/scripts/timelapse.sh
+++ b/firmware_mod/scripts/timelapse.sh
@@ -5,7 +5,7 @@
 
 PIDFILE='/run/timelapse.pid'
 TIMELAPSE_CONF='/system/sdcard/config/timelapse.conf'
-SAVE_DIR='/system/sdcard/DCIM/timelapse'
+BASE_SAVE_DIR='/system/sdcard/DCIM/timelapse'
 
 if [ -f "$TIMELAPSE_CONF" ]; then
     . "$TIMELAPSE_CONF" 2>/dev/null
@@ -13,9 +13,6 @@ fi
 
 if [ -z "$TIMELAPSE_INTERVAL" ]; then TIMELAPSE_INTERVAL=2.0; fi
 
-if [ ! -d "$SAVE_DIR" ]; then
-    mkdir -p $SAVE_DIR
-fi
 
 # because``date`` doesn't support milliseconds +%N
 # we have to use a running counter to generate filenames
@@ -24,6 +21,13 @@ last_prefix=''
 ts_started=$(date +%s)
 
 while true; do
+    SAVE_DIR=$BASE_SAVE_DIR
+    if [ $SAVE_DIR_PER_DAY -eq 1 ]; then
+        SAVE_DIR="$BASE_SAVE_DIR/$(date +%Y-%m-%d)"
+    fi
+    if [ ! -d "$SAVE_DIR" ]; then
+        mkdir -p $SAVE_DIR
+    fi
     filename_prefix="$(date +%Y-%m-%d_%H%M%S)"
     if [ "$filename_prefix" = "$last_prefix" ]; then
         counter=$(($counter + 1))
@@ -33,7 +37,11 @@ while true; do
     fi
     counter_formatted=$(printf '%03d' $counter)
     filename="${filename_prefix}_${counter_formatted}.jpg"
-    /system/sdcard/bin/getimage > "$SAVE_DIR/$filename" &
+    if [ -z "$COMPRESSION_QUALITY" ]; then
+         /system/sdcard/bin/getimage > "$SAVE_DIR/$filename" &
+    else
+        /system/sdcard/bin/getimage | /system/sdcard/bin/jpegoptim -m"$COMPRESSION_QUALITY" --stdin --stdout > "$SAVE_DIR/$filename" &
+    fi
     sleep $TIMELAPSE_INTERVAL
 
     if [ $TIMELAPSE_DURATION -gt 0 ]; then


### PR DESCRIPTION
Add 2 new options to timelapse.conf:

- SAVE_DIR_PER_DAY
if set to 1, will create a new subfolder for each day to save the images

- COMPRESSION_QUALITY
used with jpegoptim to add compression to the saved images

If no changes are made to the timelapse.conf file everything will work as before.