### PR TITLE
Add an API call to trigger sendPictureMail

### DIFF
--- a/firmware_mod/scripts/sendPictureMail.sh
+++ b/firmware_mod/scripts/sendPictureMail.sh
@@ -4,6 +4,12 @@ boundary="ZZ_/afg6432dfgkl.94531q"
 FILENAME=$(date "+%Y%m%d%H%M%S-")
 MAILDATE=$(date -R)
 
+if [ ! -f /system/sdcard/config/sendmail.conf ]
+then
+  echo "You must configure /system/sdcard/config/sendmail.conf before using sendPictureMail"
+  exit 1
+fi
+
 . /system/sdcard/config/sendmail.conf
 
 # Build headers of the emails

--- a/firmware_mod/www/cgi-bin/api.cgi
+++ b/firmware_mod/www/cgi-bin/api.cgi
@@ -327,6 +327,14 @@ if [ -n "$F_action" ]; then
     busybox rmmod sample_motor  2>&1
     $BINPATH/busybox nohup /system/bin/iCamera &  &>/dev/null &
   ;;
+  send_picture_mail)
+    $SDPATH/scripts/sendPictureMail.sh
+    if [ $? == 0 ]; then
+      getReturn 1234 "success" "sendPictureMail completed successfully"
+    else
+      getReturn 1234 "error" "sendPictureMail failed"
+    fi
+  ;;
   *)
   getReturn 1234 "error" "Unsupported command '$F_action'"
   ;;


### PR DESCRIPTION
Added an api endpoint for triggering sendPictureMail. This is useful for me so I can get openhab to trigger when motion is detected via external sensors (not the motion detection on the dafang).

@kszere I'm not sure if this PR should be here, or in https://github.com/kszere/Custom-Software-For-Xiaomi-Dafang, or how https://github.com/kszere/Custom-Software-For-Xiaomi-Dafang gets back into this repo.

Any help appreciated :)