### PR TITLE
Allow custom scripts to run on motion detection on/off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ firmware_mod/config/rtspserver.conf
 firmware_mod/config/ntp_srv.conf
 firmware_mod/config/lighttpd.user
 firmware_mod/config/lighttpd.pem
+firmware_mod/config/userscripts/*/*
 firmware_mod/root/.ssh/*

--- a/firmware_mod/scripts/detectionOff.sh
+++ b/firmware_mod/scripts/detectionOff.sh
@@ -14,3 +14,11 @@ if [ "$publish_mqtt_message" = true ] ; then
 	. /system/sdcard/config/mqtt.conf
 	/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -m "OFF"
 fi
+
+# Run any user scripts.
+if [ -f /system/sdcard/config/userscripts/motiondetection/* ]; then
+    for i in /system/sdcard/config/userscripts/motiondetection/*; do
+        echo "Running: $i off"
+        $i off
+    done
+fi

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -37,3 +37,11 @@ fi
 if [ "$sendemail" = true ] ; then
     /system/sdcard/scripts/sendPictureMail.sh&
 fi
+
+# Run any user scripts.
+if [ -f /system/sdcard/config/userscripts/motiondetection/* ]; then
+    for i in /system/sdcard/config/userscripts/motiondetection/*; do
+        echo "Running: $i on"
+        $i on
+    done
+fi


### PR DESCRIPTION
Hi,

I have a need for running custom scripts on motion detection. For example, I want to run `sendPictureMail.sh` but only on certain (external) conditions. So I disable sendmail, and run my own script to trigger it.

This covers my needs by allowing me to specify my own scripts in `config/userscripts/motiondetection` that will get executed. The first argument passed is 'on' or 'off' depending whether motion detection started or ended.

Any suggestions welcome. Seems to work ok for me here.

