### PR TITLE
Check if the sdcard is mounted readonly and warn user

### DIFF
--- a/firmware_mod/www/cgi-bin/status.cgi
+++ b/firmware_mod/www/cgi-bin/status.cgi
@@ -7,6 +7,29 @@ echo ""
 
 # source header.cgi
 
+mount|grep "/system/sdcard"|grep "rw,">/dev/null
+
+if [ $? == 1 ]; then
+
+cat << EOF
+  <!-- sdcard warning -->
+  <article class="message is-warning">
+    <div class="message-header">
+      <p>Warning</p>
+      <button class="delete" aria-label="delete"></button>
+    </div>
+    <div class="message-body">
+      Your sdcard is mounted read-only. Settings can't be saved.
+      <br>
+      <p>Please try rebooting. If the problem persists, please <a target="_blank" href="https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/search?q=read+only+sdcard&type=Issues">searc
+      for possible solutions.</p>
+    </div>
+  </article>
+  <!-- end sdcard warning -->
+EOF
+
+fi
+
 cat << EOF
 <!-- Date -->
 <div class='card status_card'>


### PR DESCRIPTION
There's been a couple of instances where peoples sdcard have gone readonly and settings don't save. I've added a check for this and will warn them if it's not mounted read-write.