### PR TITLE
Fix "Axis" disappearance in OSD (#463)

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -376,6 +376,6 @@ update_axis(){
   source /system/sdcard/config/osd.conf > /dev/null 2>/dev/null
   AXIS=`/system/sdcard/bin/motor -d s | sed '3d' | awk '{printf ("%s ",$0)}' | awk '{print "X="$2,"Y="$4}'`
   if [ "$DISPLAY_AXIS" == "true" ]; then
-    OSD=$(echo ${OSD} | sed -r "s/X=.*$/${AXIS}/")
+    OSD="${OSD} ${AXIS}"
   fi
 }


### PR DESCRIPTION
Sorry, the last PR fix was not completed. It generated a new bug #463.

Fixes #463