### PR TITLE
bind mount /bin/busybox to sdcard one

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -33,6 +33,8 @@ if [ ! -d /system/sdcard/etc ]; then
   sed -i s#/:#/root:# /system/sdcard/etc/passwd
   echo "Created etc directory on sdcard" >> $LOGPATH
 fi
+mount -o bind /system/sdcard/bin/busybox /bin/busybox
+echo "Bind mounted /system/sdcard/bin/busybox to /bin/busybox" >> $LOGPATH
 mount -o bind /system/sdcard/root /root
 echo "Bind mounted /system/sdcard/root to /root" >> $LOGPATH
 mount -o bind /system/sdcard/etc /etc


### PR DESCRIPTION
Previously /bin/busybox was the squashfs shipped busybox binary, which
was lacking many features, even with some squashfs shipped symlinks such
as /usr/bin/basename (which is a compat symlink) not working.

This change bind mounts /system/sdcard/bin/busybox to /bin/busybox,
which effectively overrides the squashfs busybox.  This is done on each
boot via run.sh

Closes: #477

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>