### PR TITLE
Add standard periodic cronjobs

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -40,8 +40,24 @@ echo "Bind mounted /system/sdcard/etc to /etc" >> $LOGPATH
 
 ## Create crontab dir and start crond:
 if [ ! -d /system/sdcard/config/cron ]; then
-  mkdir -p /system/sdcard/config/cron/crontabs
-  echo "Created cron directory" >> $LOGPATH
+  mkdir -p ${CONFIGPATH}/cron/crontabs
+  CRONPERIODIC="${CONFIGPATH}/cron/periodic"
+  echo ${CONFIGPATH}/cron/crontabs/periodic
+  # Wish busybox sh had brace expansion...
+  mkdir -p ${CRONPERIODIC}/15min \
+           ${CRONPERIODIC}/hourly \
+           ${CRONPERIODIC}/daily \
+           ${CRONPERIODIC}/weekly \
+           ${CRONPERIODIC}/monthly
+  cat > ${CONFIGPATH}/cron/crontabs/root <<EOF
+# min   hour    day     month   weekday command
+*/15    *       *       *       *       busybox run-parts ${CRONPERIODIC}/15min
+0       *       *       *       *       busybox run-parts ${CRONPERIODIC}/hourly
+0       2       *       *       *       busybox run-parts ${CRONPERIODIC}/daily
+0       3       *       *       6       busybox run-parts ${CRONPERIODIC}/weekly
+0       5       1       *       *       busybox run-parts ${CRONPERIODIC}/monthly
+EOF
+  echo "Created cron directories and standard interval jobs" >> $LOGPATH
 fi
 /system/sdcard/bin/busybox crond -L /system/sdcard/log/crond.log -c /system/sdcard/config/cron/crontabs
 


### PR DESCRIPTION
Previously adding a cronjob meant adding it to the root crontab with
appropriate syntax.  This change adds some standard periodic locations,
where simply dropping in a shell script into a folder means it will be
executed on schedule.  Adding specific jobs remains unaffected by this
change, and upgrades will not be touched.

The periodic jobs are:
  - 15min (every 15 mins)
  - hourly (on the hour)
  - daily (02:00 everyday)
  - weekly (03:00 on Saturday)
  - monthly (05:00 on first of month)

ie, adding a script to:
 - /system/sdcard/config/cron/periodic/15min/foo.sh
will execute every 15 mins.

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>