### PR TITLE
Fix CGI execution and add cgi stderr logging

### DIFF
--- a/firmware_mod/config/lighttpd.conf.dist
+++ b/firmware_mod/config/lighttpd.conf.dist
@@ -50,6 +50,9 @@ $HTTP["scheme"] == "http" {
 ## where to send error-messages to
 server.errorlog             = "/tmp/lighttpd-error.log"
 
+## CGI (etc) stderr log
+server.breakagelog = "/tmp/lighttpd-cgi-stderr.log"
+
 ## accesslog module
 accesslog.filename          = "/tmp/lighttpd-access.log"
 

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -5,7 +5,7 @@ echo "Pragma: no-cache"
 echo "Cache-Control: max-age=0, no-store, no-cache"
 echo ""
 
-source func.cgi
+source ./func.cgi
 source /system/sdcard/scripts/common_functions.sh
 
 export LD_LIBRARY_PATH=/system/lib

--- a/firmware_mod/www/cgi-bin/api.cgi
+++ b/firmware_mod/www/cgi-bin/api.cgi
@@ -5,7 +5,7 @@
 # kszere@gmail.com | 2018-01-31 |  v0.0.5 Beta #
 ################################################
 
-source func.cgi
+source ./func.cgi
 
 # START VARIABLES
 PATH="/system/bin:/bin:/usr/bin:/sbin:/usr/sbin:/media/mmcblk0p2/data/bin:/media/mmcblk0p2/data/sbin:/media/mmcblk0p2/data/usr/bin"

--- a/firmware_mod/www/cgi-bin/missile_cmd.cgi
+++ b/firmware_mod/www/cgi-bin/missile_cmd.cgi
@@ -1,5 +1,5 @@
 #!/bin/sh
-source func.cgi
+source ./func.cgi
 export LD_LIBRARY_PATH=/system/sdcard/lib
 CMD=$F_cmd
 

--- a/firmware_mod/www/cgi-bin/network.cgi
+++ b/firmware_mod/www/cgi-bin/network.cgi
@@ -4,7 +4,7 @@ echo "Content-type: text/html"
 echo "Pragma: no-cache"
 echo "Cache-Control: max-age=0, no-store, no-cache"
 echo ""
-source func.cgi
+source ./func.cgi
 if [ -e "/etc/fang_hacks.cfg" ]; then source /etc/fang_hacks.cfg; fi
 PATH="/bin:/sbin:/usr/bin:/system/bin"
 

--- a/firmware_mod/www/cgi-bin/scripts.cgi
+++ b/firmware_mod/www/cgi-bin/scripts.cgi
@@ -1,5 +1,5 @@
 #!/bin/sh
-source func.cgi
+source ./func.cgi
 
 echo "Pragma: no-cache"
 echo "Cache-Control: max-age=0, no-store, no-cache"

--- a/firmware_mod/www/cgi-bin/state.cgi
+++ b/firmware_mod/www/cgi-bin/state.cgi
@@ -2,7 +2,7 @@
 
 # A very light-weight interface just for responsive ui to get states
 
-source func.cgi
+source ./func.cgi
 source /system/sdcard/scripts/common_functions.sh
 
 


### PR DESCRIPTION
Change #478 introduced a regression with the updated busybox where ".",
seems not be part of the default $PATH.

The cgi scripts were sourcing "func.cgi", but this could not be found in
the new default $PATH, and therefore failed to execute. This meant that
the web-ui was unable to make changes and execute commands.

This has been resolved by putting a leading "./" for the script, making
it now ./func.cgi.

In addition, this also adds the lighttpd option server.breakagelog,
which enables stderr logging to /tmp/lighttpd-cgi-stderr.log (so 500
internal errors output is now logged to file (previously just the error
500 was in the webserver logs).

Closes: #491

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>