### PR TITLE
Ugh, missile.cgi had a relative source aswell

### DIFF
--- a/firmware_mod/www/cgi-bin/missile.cgi
+++ b/firmware_mod/www/cgi-bin/missile.cgi
@@ -23,7 +23,7 @@ cat << EOF
 <body>
 EOF
 
-source header.cgi
+source ./header.cgi
 
 cat << EOF
 <br/>


### PR DESCRIPTION
In the previous commit, func.cgi sourcing was fixed by adding a leading
"./" to the filename.

However, I missed that missile.cgi had a cheeky source of header.cgi
which I missed in the previous change.

Closes: #491

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>