### PR TITLE
Close link to fix UI bug - entire page was "clickable"

### DIFF
--- a/firmware_mod/www/cgi-bin/status.cgi
+++ b/firmware_mod/www/cgi-bin/status.cgi
@@ -21,8 +21,8 @@ cat << EOF
     <div class="message-body">
       Your sdcard is mounted read-only. Settings can't be saved.
       <br>
-      <p>Please try rebooting. If the problem persists, please <a target="_blank" href="https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/search?q=read+only+sdcard&type=Issues">searc
-      for possible solutions.</p>
+      <p>Please try rebooting. If the problem persists, please <a target="_blank" href="https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/search?q=read+only+sdcard&type=Issues">search
+      for possible solutions.</a></p>
     </div>
   </article>
   <!-- end sdcard warning -->


### PR DESCRIPTION
The entire page was clickable and thus other settings could not be used as it always opened a new tab.