### PR TITLE
Fix curl request to action.cgi from mqtt-control.sh after enforced ssl

### DIFF
--- a/firmware_mod/scripts/mqtt-control.sh
+++ b/firmware_mod/scripts/mqtt-control.sh
@@ -180,7 +180,7 @@ killall mosquitto_sub.bin 2> /dev/null
     "${TOPIC}/set "*)
       COMMAND=$(echo "$line" | awk '{print $2}')
       #echo "$COMMAND"
-      /system/sdcard/bin/curl -m 2 ${CURLOPTS} -s http://127.0.0.1/cgi-bin/action.cgi\?cmd="${COMMAND}" -o /dev/null 2>/dev/null
+      /system/sdcard/bin/curl -k -m 2 ${CURLOPTS} -s https://127.0.0.1/cgi-bin/action.cgi\?cmd="${COMMAND}" -o /dev/null 2>/dev/null
       if [ $? -eq 0 ]; then
         /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}/${COMMAND}" ${MOSQUITTOOPTS} -m "OK (this means: action.cgi invoke with parameter ${COMMAND}, nothing more, nothing less)"
       else


### PR DESCRIPTION
Due to an enforced redirect to https, the curl requests to action.cgi weren't working anymore.


