### PR TITLE
Fix video size setting in web ui Settings page

### DIFF
--- a/firmware_mod/www/cgi-bin/status.cgi
+++ b/firmware_mod/www/cgi-bin/status.cgi
@@ -391,11 +391,11 @@ cat << EOF
                         <div class="control">
                             <div class="select">
                                 <select name="video_size">
-                                <option value="-W640 -H360" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep 640)" != "" ]; then echo selected; fi)>640x360</option>
-                                <option value="-W960 -H540" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep 960)" != "" ]; then echo selected; fi)>960x540</option>
-                                <option value="-W1280 -H720" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep 1280)" != "" ]; then echo selected; fi)>1280x720</option>
-                                <option value="-W1600 -H900" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep 1600)" != "" ]; then echo selected; fi)>1600x900</option>
-                                <option value="-W1920 -H1080" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep 1920)" != "" ]; then echo selected; fi)>1920x1080</option>
+                                <option value="-W640 -H360" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep '^RTSPH264OPTS="-W640')" != "" ]; then echo selected; fi)>640x360</option>
+                                <option value="-W960 -H540" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep '^RTSPH264OPTS="-W960')" != "" ]; then echo selected; fi)>960x540</option>
+                                <option value="-W1280 -H720" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep '^RTSPH264OPTS="-W1280')" != "" ]; then echo selected; fi)>1280x720</option>
+                                <option value="-W1600 -H900" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep '^RTSPH264OPTS="-W1600')" != "" ]; then echo selected; fi)>1600x900</option>
+                                <option value="-W1920 -H1080" $(if [ "$(cat /system/sdcard/config/rtspserver.conf | grep '^RTSPH264OPTS="-W1920')" != "" ]; then echo selected; fi)>1920x1080</option>
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
Video size gets stuck at 1600x900. Current grep isn't specific enough to pick up the video size setting from rtspserver.conf. It doesn't take into account  #commented lines with video sizes and by default, greps the "1600" part of AUDIOINBR=16000 which is why it's always reverts back to 1600x900 unless AUDIOINBR is set to a different value.  Since there's only 1 Video Size selector, both RTSPH264OPTS and RTSPMJPEGOPTS will always be set to the same size in rtspserver.conf. Therefor, grepping either of them should be sufficient to set the "selected" value.

**Maintainers:**  This is my first attempt at a pull request to please let me know if i did something wrong.