### PR TITLE
Make uboot-flash script work from every location

### DIFF
--- a/firmware_mod/uboot-flash/flash_opensource_t20.sh
+++ b/firmware_mod/uboot-flash/flash_opensource_t20.sh
@@ -1,2 +1,2 @@
 flash_eraseall /dev/mtd0
-dd if=opensource-T20-V1.2.bin of=/dev/mtd0
+dd if=/system/sdcard/uboot-flash/opensource-T20-V1.2.bin of=/dev/mtd0

--- a/firmware_mod/uboot-flash/flash_original_dafang.sh
+++ b/firmware_mod/uboot-flash/flash_original_dafang.sh
@@ -1,2 +1,2 @@
 flash_eraseall /dev/mtd0
-dd if=dafang-uboot.bin of=/dev/mtd0
+dd if=/system/sdcard/uboot-flash/dafang-uboot.bin of=/dev/mtd0


### PR DESCRIPTION
flashinguboot.md tells the user to just SSH into the camera and execute "/system/sdcard/uboot-flash/flash_opensource_t20.sh" which did not work before (was looking for .bin files in the local folder).