### PR TITLE
When sending mail, allow option for 'default' compression which allows for shorter gaps between images

### DIFF
--- a/firmware_mod/config/sendmail.conf.dist
+++ b/firmware_mod/config/sendmail.conf.dist
@@ -30,5 +30,5 @@ TIMEBETWEENSNAPSHOT=5
 
 # Quality of compression (Valid quality values: 0 - 100, 100% is best)
 # Set to -1 for no compression
+# Set to -2 for default compression (No -m option to jpegoptim,faster,but larger images)
 QUALITY=50
-

--- a/firmware_mod/scripts/sendPictureMail.sh
+++ b/firmware_mod/scripts/sendPictureMail.sh
@@ -48,10 +48,13 @@ Content-Disposition: attachment; filename=\"${FILENAME}${i}.jpg\"
 
     if [ ${QUALITY} -eq -1 ]
     then
-        /system/sdcard/bin/getimage | /system/sdcard/bin/openssl enc -base64
-    else
-       /system/sdcard/bin/getimage |  /system/sdcard/bin/jpegoptim -m${QUALITY} --stdin --stdout  | /system/sdcard/bin/openssl enc -base64
-
+       /system/sdcard/bin/getimage | /system/sdcard/bin/openssl enc -base64
+    else if [ ${QUALITY} -eq -2 ]
+        then
+           /system/sdcard/bin/getimage |  /system/sdcard/bin/jpegoptim --stdin --stdout  | /system/sdcard/bin/openssl enc -base64
+        else
+           /system/sdcard/bin/getimage |  /system/sdcard/bin/jpegoptim -m${QUALITY} --stdin --stdout  | /system/sdcard/bin/openssl enc -base64
+        fi
     fi
 
     echo


### PR DESCRIPTION
Compression seems to be approx. 4x as fast than when specifying the -m option, but the still approx. 90% smaller than the original file size