### PR TITLE
/system/sdcard/run.sh: make sure ntpd gets run AFTER wifi and internet is working (with timeout)

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -119,6 +119,7 @@ if [ ! -f $CONFIGPATH/ntp_srv.conf ]; then
   cp $CONFIGPATH/ntp_srv.conf.dist $CONFIGPATH/ntp_srv.conf
 fi
 ntp_srv="$(cat "$CONFIGPATH/ntp_srv.conf")"
+timeout -t 30 sh -c "until ping -c1 \"$ntp_srv\" &>/dev/null; do sleep 3; done";
 /system/sdcard/bin/busybox ntpd -p "$ntp_srv"
 
 ## Load audio driver module:


### PR DESCRIPTION
Change
/system/sdcard/bin/busybox ntpd -p "$ntp_srv"
to 
timeout -t 30 sh -c "until ping -c1 "$ntp_srv" &>/dev/null; do sleep 3; done";
/system/sdcard/bin/busybox ntpd -p "$ntp_srv"

This will wait up to 30sec for wifi and internet and ntp timeserver access to start working.
If this is not done, a race condition often causes time to be set to 1970 (unix epoch start),
and time may never get updated.