### PR TITLE
Remove oldest snaps when save_dir is full & run user motion scripts in background

### DIFF
--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -17,7 +17,7 @@ if [ "$save_snapshot" = true ] ; then
 	fi
 	# Limit the number of snapshots
 	if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
-		rm -f "$save_dir/$(ls -l "$save_dir" | awk 'NR==2{print $9}')"
+		rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
 	fi
 	/system/sdcard/bin/getimage > "$save_dir/$filename" &
 fi
@@ -52,6 +52,6 @@ fi
 for i in /system/sdcard/config/userscripts/motiondetection/*; do
     if [ -x "$i" ]; then
         echo "Running: $i on"
-        $i on
+        $i on &
     fi
 done

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -15,10 +15,12 @@ if [ "$save_snapshot" = true ] ; then
 	if [ ! -d "$save_dir" ]; then
 		mkdir -p "$save_dir"
 	fi
-	# Limit the number of snapshots
-	if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
-		rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
-	fi
+	{
+		# Limit the number of snapshots
+		if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
+			rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
+		fi
+	} &
 	/system/sdcard/bin/getimage > "$save_dir/$filename" &
 fi
 


### PR DESCRIPTION
The removal is done in background, as it blocks for 2 or 3 seconds.

