### PR TITLE
Fix for missing Mosquitto options for main subscription loop in mqtt-control.sh

### DIFF
--- a/firmware_mod/scripts/mqtt-control.sh
+++ b/firmware_mod/scripts/mqtt-control.sh
@@ -6,7 +6,7 @@
 killall mosquitto_sub 2> /dev/null
 killall mosquitto_sub.bin 2> /dev/null
 
-/system/sdcard/bin/mosquitto_sub.bin -v -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/# | while read -r line ; do
+/system/sdcard/bin/mosquitto_sub.bin -v -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/# ${MOSQUITTOOPTS} | while read -r line ; do
   case $line in
     "${TOPIC}/set help")
       /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/help ${MOSQUITTOOPTS} -m "possible commands: configured topic + Yellow_LED/set on/off, configured topic + Blue_LED/set on/off, configured topic + set with the following commands: status, $(grep \)$ /system/sdcard/www/cgi-bin/action.cgi | grep -v '[=*]' | sed -e "s/ //g" | grep -v -E '(osd|setldr|settz|showlog)' | sed -e "s/)//g")"


### PR DESCRIPTION
Fixed missing ${MOSQUITTOOPTS} for the subscription loop, this causes users with TLS parameters to be unable to receive control input via MQTT