### PR TITLE
Fixing telegram integration in detectionOn.sh

### DIFF
--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -44,9 +44,9 @@ if [ "$send_telegram" = true ]; then
 	if [ "$save_snapshot" = true ] ; then
 		/system/sdcard/bin/telegram p "$save_dir/$filename"
 	else
-		/system/sdcard/bin/getimage > "$save_dir/telegram_image.jpg"
- 	/system/sdcard/bin/telegram p "$save_dir/telegram_image.jpg"
- 	rm "$save_dir/telegram_image.jpg"
+		/system/sdcard/bin/getimage > "/tmp/telegram_image.jpg"
+ 		/system/sdcard/bin/telegram p "/tmp/telegram_image.jpg"
+ 		rm "/tmp/telegram_image.jpg"
 	fi
 fi
 

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -44,9 +44,9 @@ if [ "$send_telegram" = true ]; then
 	if [ "$save_snapshot" = true ] ; then
 		/system/sdcard/bin/telegram p "$save_dir/$filename"
 	else
-		/system/sdcard/bin/getimage > "telegram_image.jpg"
- +	/system/sdcard/bin/telegram p "telegram_image.jpg"
- +	rm "telegram_image.jpg"
+		/system/sdcard/bin/getimage > "$save_dir/telegram_image.jpg"
+ 	/system/sdcard/bin/telegram p "$save_dir/telegram_image.jpg"
+ 	rm "$save_dir/telegram_image.jpg"
 	fi
 fi
 


### PR DESCRIPTION
The (+) symbols on lines 48/49 of the original file look like they were left there from some other automated process or diff but they break the Telegram integration of the script.

Additionally, if you don't have save_snapshot set to true, the cwd that this script runs in does not work for saving images, so getimage fails.  To fix both these problems, I removed the +es and added in the $save_dir reference.

Additionally, the block that creates the $save_dir if it doesn't exist should probably be replicated too down in the Telegram section if $save_snapshot is false, but I didn't put it there because I'm not sure if you might just want to have that run one time in common_functions or something like that.