### PR TITLE
add snapshot function, mqtt pub/sub snapshot

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -385,6 +385,7 @@ snapshot(){
   if [ "$1" == "on" ]; then
     filename="/tmp/snapshot.jpg"
     /system/sdcard/bin/getimage > "$filename" &
+    sleep 1
   fi
 }
 

--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -380,13 +380,11 @@ auto_night_mode(){
   esac
 }
 
-# Take/store a snapshot
+# Take a snapshot
 snapshot(){
-  if [ "$1" == "on" ]; then
     filename="/tmp/snapshot.jpg"
     /system/sdcard/bin/getimage > "$filename" &
     sleep 1
-  fi
 }
 
 # Update axis

--- a/firmware_mod/scripts/mqtt-control.sh
+++ b/firmware_mod/scripts/mqtt-control.sh
@@ -191,8 +191,8 @@ killall mosquitto_sub.bin 2> /dev/null
       /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motors/horizontal ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(motor status horizontal)"
     ;;
     
-    "${TOPIC}/snapshot/take ON")
-      snapshot on
+    "${TOPIC}/snapshot/set ON")
+      snapshot
       /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/snapshot ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -f "$filename"
     ;;
 


### PR DESCRIPTION
Added .jpg snapshot function to common_functions.sh and mqtt pub/sub section to subscribe to topic which, when turned "ON" takes a snapshot and publishes on {topic}/snapshot. This is different from the snapshot sent during motion in that it allows the user to request a snapshot at any time, especially if/when utilizing an mqtt "camera" where could request a .jpg every 5, 10...30 seconds.