### PR TITLE
Ref #727 - Allow snapshot filename to be configured in motion.conf

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -19,3 +19,4 @@ publish_mqtt_message=false
 sendemail=false
 send_telegram=false
 save_dir=/system/sdcard/motion/stills
+save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -11,7 +11,8 @@ fi
 
 # Save a snapshot
 if [ "$save_snapshot" = true ] ; then
-	filename=$(date +%d-%m-%Y_%H.%M.%S).jpg
+	pattern="${save_file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
+	filename=$(date $pattern).jpg
 	if [ ! -d "$save_dir" ]; then
 		mkdir -p "$save_dir"
 	fi


### PR DESCRIPTION
ref: #727 Allow snapshot filename to be configured in motion.conf. Will default to `+%d-%m-%Y_%H.%M.%S` in the case that motion.conf has not been updated.