### PR TITLE
Fix for zero byte files overwriting local files

### DIFF
--- a/firmware_mod/autoupdate.sh
+++ b/firmware_mod/autoupdate.sh
@@ -260,6 +260,12 @@ do
         echo "Can not get remote file $i, exiting."
         exit 1
     fi
+    # sometimes zero byte files are received, which overwrite the local files, we ignore those files
+    # exception: files that are hidden i.e. start with dot. Ex: files like ".gitkeep"
+    if [[ ! -s ${TMPFILE} ]] && [[ $(basename ${LOCALFILE} | cut -c1-1) != "." ]
+        echo "Received zero byte file $i, exiting."                             
+        exit 1                                                                  
+    fi   
     # Check the file exists in local
     if [ -f "${DESTFOLDER}/${LOCALFILE}" ]; then
         REMOTESHA=$(${SHA} ${TMPFILE} 2>/dev/null | cut -d "=" -f 2)


### PR DESCRIPTION
This commit fixes zero byte files overwriting local files, making camera unbootable

Fixes https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/issues/754