### PR TITLE
Add a new parameter 'publish_mqtt_snapshot'

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -13,9 +13,13 @@ motion_tracking=off
 # Configure how to deal with motion events:
 
 motion_trigger_led=true
-save_snapshot=false
 max_snapshots=20
+# Notify about motion
 publish_mqtt_message=false
+# Send the actual image via mqtt
+publish_mqtt_snapshot=false
+# Save the image locally
+save_snapshot=false
 sendemail=false
 send_telegram=false
 save_dir=/system/sdcard/motion/stills

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -29,10 +29,13 @@ fi
 if [ "$publish_mqtt_message" = true ] ; then
 	. /system/sdcard/config/mqtt.conf
 	/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -m "ON"
-	if [ "$save_snapshot" = true ] ; then
-		/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion/snapshot ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -f "$save_dir/$filename"
-	fi
+fi
 
+# The MQTT publish uses a separate image from the "save_snapshot" to keep things simple 
+if [ "$publish_mqtt_snapshot" = true ] ; then
+	/system/sdcard/bin/getimage > /tmp/last_image.jpg
+	/system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motion/snapshot ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -f /tmp/last_image.jpg
+	rm /tmp/last_image.jpg
 fi
 
 # Send emails ...

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -560,12 +560,20 @@ if [ -n "$F_cmd" ]; then
           rewrite_config /system/sdcard/config/motion.conf save_snapshot "false"
           return
           ;;
-     motion_detection_mqtt_on)
+     motion_detection_mqtt_publish_on)
           rewrite_config /system/sdcard/config/motion.conf publish_mqtt_message "true"
           return
           ;;
-     motion_detection_mqtt_off)
+     motion_detection_mqtt_publish_off)
           rewrite_config /system/sdcard/config/motion.conf publish_mqtt_message "false"
+          return
+          ;;
+     motion_detection_mqtt_snapshot_on)
+          rewrite_config /system/sdcard/config/motion.conf publish_mqtt_snapshot "true"
+          return
+          ;;
+     motion_detection_mqtt_snapshot_off)
+          rewrite_config /system/sdcard/config/motion.conf publish_mqtt_snapshot "false"
           return
           ;;
 

--- a/firmware_mod/www/cgi-bin/state.cgi
+++ b/firmware_mod/www/cgi-bin/state.cgi
@@ -114,6 +114,15 @@ if [ -n "$F_cmd" ]; then
       echo "OFF"
     fi
     ;;
+  motion_mqtt_snapshot)
+    . /system/sdcard/config/motion.conf 2> /dev/null
+    if [ "$publish_mqtt_snapshot" == "true" ]; then
+      echo "ON"
+    else
+      echo "OFF"
+    fi
+    ;;
+
 
   hostname)
     echo $(hostname);

--- a/firmware_mod/www/index.html
+++ b/firmware_mod/www/index.html
@@ -296,9 +296,15 @@
                             </span>
                             <!-- Motion: MQTT Message -->
                             <span class="navbar-item">
-                                <input id="motion_mqtt" type="checkbox" name="motion_mqtt" class="switch" data-checked="cgi-bin/action.cgi?cmd=motion_detection_mqtt_on"
-                                       data-unchecked="cgi-bin/action.cgi?cmd=motion_detection_mqtt_off">
+                                <input id="motion_mqtt" type="checkbox" name="motion_mqtt" class="switch" data-checked="cgi-bin/action.cgi?cmd=motion_detection_mqtt_publish_on"
+                                       data-unchecked="cgi-bin/action.cgi?cmd=motion_detection_mqtt_publish_off">
                                 <label for="motion_mqtt">Motion - MQTT Message</label>
+                            </span>
+                            <!-- Motion: MQTT Message -->
+                            <span class="navbar-item">
+                                <input id="motion_mqtt_snapshot" type="checkbox" name="motion_mqtt_snapshot" class="switch" data-checked="cgi-bin/action.cgi?cmd=motion_detection_mqtt_snapshot_on"
+                                       data-unchecked="cgi-bin/action.cgi?cmd=motion_detection_mqtt_snapshot_off">
+                                <label for="motion_mqtt">Motion - MQTT Snapshot</label>
                             </span>
                         </div>
                     </div>

--- a/firmware_mod/www/scripts/index.html.js
+++ b/firmware_mod/www/scripts/index.html.js
@@ -3,7 +3,7 @@ var SWITCHES = [
     "rtsp_h264", "rtsp_mjpeg", "auto_night_detection",
     "mqtt_status", "mqtt_control",
     "sound_on_startup", "motion_detection", "motion_mail",
-    "motion_led","motion_snapshot","motion_mqtt"];
+    "motion_led","motion_snapshot","motion_mqtt", "motion_mqtt_snapshot"];
 
 var timeoutJobs = {};
 

--- a/integration/homeassistant/homeassistant.md
+++ b/integration/homeassistant/homeassistant.md
@@ -91,7 +91,10 @@ For your camera to send mqtt motion detection messages it should be enabled by s
 ```
 publish_mqtt_message=true
 ```
-
+To publish the image itself, also set
+```
+publish_mqtt_snapshot=true
+```
 You should now be getting messages on topic `myhome/mycamera/motion` and images on `myhome/mycamera/motion/snapshot` while    `myhome/mycamera/motion/detection` is set to ON
 
 To react on a motion event, in your automations.yaml define something like:


### PR DESCRIPTION
Currently, publish_mqtt_message is used to decide whether we send a
notification about motion. save_snapshot is used to save the image
locally. And if both are set, the image is also sent to mqtt

This PR decouples the mqtt image send from the snapshot saving. There
are now three parameters:

publish_mqtt_message -- send notification that there was motion
publish_mqtt_snapshot -- send notification containing the motion.
save_snapshot -- saves to disk, doesn't necessarily notify

No MQTT topics are changed; this is purely configuration bookkeeping.