### PR TITLE
 Log by default to /tmp so as to avoid SD card corruption

### DIFF
--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -1,6 +1,6 @@
 #!/bin/sh
 PIDFILE="/run/v4l2rtspserver-master-h264.pid"
-LOGDIR="/tmp/log"
+LOGDIR="/tmp"
 LOGPATH="$LOGDIR/v4l2rtspserver-master.log"
 export LD_LIBRARY_PATH='/system/sdcard/lib/:/thirdlib:/system/lib'
 

--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -1,6 +1,6 @@
 #!/bin/sh
 PIDFILE="/run/v4l2rtspserver-master-h264.pid"
-LOGDIR="/system/sdcard/log"
+LOGDIR="/tmp/log"
 LOGPATH="$LOGDIR/v4l2rtspserver-master.log"
 export LD_LIBRARY_PATH='/system/sdcard/lib/:/thirdlib:/system/lib'
 

--- a/firmware_mod/controlscripts/rtsp-mjpeg
+++ b/firmware_mod/controlscripts/rtsp-mjpeg
@@ -1,6 +1,6 @@
 #!/bin/sh
 PIDFILE="/run/v4l2rtspserver-master-mjpeg.pid"
-LOGDIR="/system/sdcard/log"
+LOGDIR="/tmp"
 LOGPATH="$LOGDIR/v4l2rtspserver-master.log"
 export LD_LIBRARY_PATH='/system/sdcard/lib:/thirdlib:/system/lib'
 

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -36,7 +36,7 @@ if [ -n "$F_cmd" ]; then
 
         4)
           echo "Content of v4l2rtspserver-master.log<br/>"
-          cat /system/sdcard/log/v4l2rtspserver-master.log
+          cat /tmp/v4l2rtspserver-master.log
           ;;
 
         5)
@@ -68,7 +68,7 @@ if [ -n "$F_cmd" ]; then
           ;;
         4)
           echo "Content of v4l2rtspserver-master.log cleared<br/>"
-          echo -n "" > /system/sdcard/log/v4l2rtspserver-master.log
+          echo -n "" > /tmp/v4l2rtspserver-master.log
           ;;
         5)
           echo "Content of update.log cleared <br/>"


### PR DESCRIPTION
I discovered that the errors I was getting about the SD card similar to #880 were always related to the v4l2rtspserver log. It seems to me that especially when turning detection tracking due to the high number of writes, writing to the log causes SD card corruption. I suppose that the SD card controller is not built for such a speed. Since changing logging to log to /tmp which is mounted as tmpfs, I hadn't had any issues.

Should fix most cases of read-only partition, see: #880, #409, #648, #723, #731, #396, #457 after running `dosfsck -a /dev/mmcblk0p1`