### PR TITLE
Improved wording on motion setting config page

### DIFF
--- a/firmware_mod/www/configmotion.html
+++ b/firmware_mod/www/configmotion.html
@@ -64,7 +64,7 @@
         <div class="field">
             <div class="control">
                 <label class="checkbox">
-                    <input type="checkbox" name="motion_tracking" id="motion_tracking" onchange="setTracking(this, false)"> Enable motion tracking (when enabled no region of interest is no more used)
+                    <input type="checkbox" name="motion_tracking" id="motion_tracking" onchange="setTracking(this, false)"> Enable motion tracking (Custom set motion detection region will be ignored)
                 </label>
             </div>
         </div>


### PR DESCRIPTION
Small change: Wording was unclear on motion config page, rewrote help message.