### PR TITLE
Remove tcp_tw_recycle option set to 1

### DIFF
--- a/firmware_mod/controlscripts/configureMotion
+++ b/firmware_mod/controlscripts/configureMotion
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Motion detection (must be set before the server starting)
-# Set the socket option in order to restart easily the server (socket in use)
-echo 1 > /proc/sys/net/ipv4/tcp_tw_recycle
 
 if [ ! -f /system/sdcard/config/motion.conf ]; then
   cp /system/sdcard/config/motion.conf.dist /system/sdcard/config/motion.conf


### PR DESCRIPTION
Due to this being 1, I get  connection timeouts from HASSIO.
This option has been removed from 4.12 kernels and later as timestamps are now randomized (see https://vincent.bernat.ch/en/blog/2014-tcp-time-wait-state-linux and https://stackoverflow.com/questions/8893888/dropping-of-connections-with-tcp-tw-recycle), this means that when set to 1 we expect timestamps to behave in a certain way, but they might not.