### PR TITLE
Added bftpd as a service to the controlscripts

### DIFF
--- a/firmware_mod/controlscripts/ftp_server
+++ b/firmware_mod/controlscripts/ftp_server
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+PIDFILE="/var/run/bftpd.pid"
+
+status()
+{
+    pid="$(cat "$PIDFILE" 2>/dev/null)"
+    if [ "$pid" ]; then
+      kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
+    fi
+}
+start()
+{
+    echo "Starting bftpd server"
+    PID="$(pidof -o %PPID /system/sdcard/bin/bftpd)"
+    if [ -z "$PID" ]; then
+      /system/sdcard/bin/bftpd -d
+      if [ $? -gt 0 ]; then
+        echo "Failed to start bftpd Server"
+      else
+        # wait until it forks
+        sleep 2
+        echo $(pidof -o %PPID bftpd) > $PIDFILE
+        echo "bftpd server started"
+      fi
+    else
+      echo "Failed to start bftpd Server"
+    fi
+}
+stop()
+{
+    echo "Stopping bftpd Server"
+    if [ -f $PIDFILE ] && kill -0 $(cat $PIDFILE); then
+      kill -15 $(cat $PIDFILE)
+      rm $PIDFILE
+      echo "bftpd server stopped"
+    else
+      echo "Failed to stop bftpd Server"
+    fi
+}
+restart()
+{
+    $0 stop
+    sleep 1
+    $0 start
+}
+
+if [ $# -eq 0 ]; then
+  start
+else
+  case $1 in start|stop|restart|status)
+    $1
+    ;;
+  esac
+fi

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -180,12 +180,9 @@ else
   insmod /system/sdcard/driver/sensor_jxf23.ko data_interface=2 pwdn_gpio=-1 reset_gpio=18 sensor_gpio_func=0
 fi
 
-## Start FTP & SSH Server:
+## Start SSH Server:
 dropbear_status=$(/system/sdcard/bin/dropbearmulti dropbear -R)
 echo "dropbear: $dropbear_status" >> $LOGPATH
-
-bftpd_status=$(/system/sdcard/bin/bftpd -d)
-echo "bftpd: $bftpd_status" >> $LOGPATH
 
 ## Create a certificate for the webserver
 if [ ! -f $CONFIGPATH/lighttpd.pem ]; then


### PR DESCRIPTION
Moved the FTP server to the services tab.

Ftp servers aren't super secure, so let's not make it auto start by default. You can now start it in the services page and enable autorun if desired.

In a later stage there should be a shortcut under the `System -> Administration` page to control the FTP server (and ssh server for that matter).