### PR TITLE
detectionTracking improvements.

### DIFF
--- a/firmware_mod/scripts/detectionTracking.sh
+++ b/firmware_mod/scripts/detectionTracking.sh
@@ -1,14 +1,16 @@
 #!/bin/sh
 
 # Script to calculate the camera movement
-# The screen is split as below (0,1,2,3 are the parameters of the script)
+# The screen is split as shown below
+# (1,2,3,4 are the arguments of the script)
+#
 #           +--------------------------------------+
 #           |                    |                 |
-#           |           0        |      1          |
+#           |          1         |      2          |
 #           |                    |                 |
 #           +--------------------------------------+
 #           |                    |                 |
-#           |          2         |      3          |
+#           |          3         |      4          |
 #           |                    |                 |
 #           +--------------------------------------+
 
@@ -16,38 +18,21 @@
 
 STEPS=$STEP
 FILECAMERAPOS=/system/sdcard/config/cameraposition
-
-motorLeft(){
-      /system/sdcard/bin/motor -d l -s ${1}
-}
-
-motorRight(){
-      /system/sdcard/bin/motor -d r -s ${1}
-}
-
-motorUp() {
-      /system/sdcard/bin/motor -d u -s ${1}
-}
-
-motorDown() {
-      /system/sdcard/bin/motor -d d -s ${1}
-}
+SLEEP_NUM=$(awk -v a="${STEPS//-/}" 'BEGIN{printf ("%f",a*1.3/1000)}')
 
 backtoOrigin() {
-    # return to origin for both axis
 
-    # Get values in saved config file
     if [ -f ${FILECAMERAPOS} ]; then
-	    origin_x_axis=`grep "x:" ${FILECAMERAPOS} | sed "s/x: //"`
-	    origin_y_axis=`grep "y:" ${FILECAMERAPOS} | sed "s/y: //"`
+        # Get values in saved config file
+        origin_x_axis=`grep "x:" ${FILECAMERAPOS} | sed "s/x: //"`
+        origin_y_axis=`grep "y:" ${FILECAMERAPOS} | sed "s/y: //"`
     else
-	    /system/sdcard/bin/motor -d s > ${FILECAMERAPOS}
+        # No such file exists: create it with the current values
+        /system/sdcard/bin/motor -d s > ${FILECAMERAPOS}
     fi
 
+    # return to origin for both axis
     /system/sdcard/scripts/PTZpresets.sh $origin_x_axis $origin_y_axis
-
-    # Let some time for the motor to turn
-    sleep 1
 }
 
 #################### Start ###
@@ -56,79 +41,55 @@ backtoOrigin() {
 if [ $# -eq 0 ]
 then
     backtoOrigin
-    return 0;
+    return 0
 fi
-
-UP=0
-DOWN=0
-LEFT=0
-RIGHT=0
 
 # Display the areas ...
 echo $1 $2
 echo $3 $4
 
-
 # Sum all the parameters, that gives the number of region detected
 # Only 2 are supported
 if [ $((${1} + ${2} + ${3} +${4})) -gt 2 ]
 then
-	echo "No move if more than 3 detected regions"
+    echo "No move: more than 3 detected regions"
+    return 0
+fi
+
+# Diagonals are the only case where we have 2 opposing directions
+# (after having ruled out 3 regions or more)
+if [ [ "${1}" == "1" ] && [ "${4}" == "1" ] ] || \
+   [ [ "${2}" == "1" ] && [ "${3}" == "1" ] ]
+then
+    echo "No move: diagonally opposed regions"
     return 0
 fi
 
 # Basic algorithm to calculate the movement
-# Not optimized, if you have ideas to simplify it ...
 
 if  [ "${1}" == "1" ] || [ "${2}" == "1" ]
 then
-	UP=1
+    echo "Move up"
+    /system/sdcard/bin/motor -d u -s ${STEPS} &
 fi	
 
 if [ "${1}" == "1" ] || [ "${3}" == "1" ]
 then
-	LEFT=1
+    echo "Move left"
+    /system/sdcard/bin/motor -d l -s ${STEPS} &
 fi
 
 if [ "${2}" == "1" ] || [ "${4}" == "1" ]
 then
-	RIGHT=1
+    echo "Move right"
+    /system/sdcard/bin/motor -d r -s ${STEPS} &
 fi
 
 if [ "${3}" == "1" ] || [ "${4}" == "1" ]
 then
-	DOWN=1
+    echo "Move down"
+    /system/sdcard/bin/motor -d d -s ${STEPS} &
 fi
 
-# Some sanity checks
-if [ "${UP}" != 0 ] && [ "${DOWN}" != 0 ]
-then
-	echo "no move: up and down at the same time"
-	return 0
-fi
-if [ "${RIGHT}" != 0 ] && [ "${LEFT}" != 0 ]
-then
-	echo "no move: right and left at the same time"
-	return 0
-fi
-
-if [ ${RIGHT} != 0 ]
-then
-	echo "Right move"
-	motorRight ${STEPS}
-fi
-if [ ${LEFT} != 0 ]
-then
-	echo "Left move"
-	motorLeft ${STEPS}
-fi
-if [ ${UP} != 0 ]
-then
-	echo "Up move"
-	motorUp ${STEPS}
-fi
-if [ ${DOWN} != 0 ]
-then
-	echo "Down move"
-	motorDown ${STEPS}
-fi
+# Waiting for the motor to run.
+sleep ${SLEEP_NUM}


### PR DESCRIPTION
Remove sleep statement when running back to origin. Sleep is alredy
delat with in PTZ script.

Move sanity checks to top, which frees us from nesting caculations.

Send motor commands to background. It shouldnt be rin in the same
thread. This might solve some more time out issues with home
assistant. Add a sleep command at the end, allowing thhe motor to
run before we finish the script.