### PR TITLE
Pan tilt calibrate on boot

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -187,6 +187,9 @@ blue_led on
 ## Load motor driver module:
 insmod /driver/sample_motor.ko
 
+## Calibrate pan/tilt
+motor reset_pos_count
+
 ## Determine the image sensor model:
 insmod /system/sdcard/driver/sinfo.ko
 echo 1 >/proc/jz/sinfo/info


### PR DESCRIPTION
Make sure we got the correct position value from the get-go. Original firmware also calibrates on boot.