### PR TITLE
Provision for startup userscripts

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -239,4 +239,9 @@ for i in /system/sdcard/config/autostart/*; do
   $i
 done
 
+## Autostart startup userscripts
+for i in /system/sdcard/config/userscripts/startup/*; do             
+  $i                                                                 
+done 
+
 echo "Startup finished!" >> $LOGPATH


### PR DESCRIPTION
Users can run their scripts on startup by placing them in /system/sdcard/config/userscripts/startup directory