### PR TITLE
Update axis info in OSD when tracking motion

### DIFF
--- a/firmware_mod/scripts/detectionTracking.sh
+++ b/firmware_mod/scripts/detectionTracking.sh
@@ -18,7 +18,6 @@
 
 STEPS=$STEP
 FILECAMERAPOS=/system/sdcard/config/cameraposition
-SLEEP_NUM=0.5
 
 backtoOrigin() {
 
@@ -89,27 +88,21 @@ if [ ${RIGHT} != 0 ] && [ ${LEFT} != 0 ]; then
     LEFT=0
 fi
 
-# Do the actual movement
-if [ ${UP}    == 1 ]; then
-    echo "Move up $STEPS"
-    /system/sdcard/bin/motor -d u -s ${STEPS} &>/dev/null
-    sleep ${SLEEP_NUM}
-fi
+# Do the actual movement in the background
+(
+    if [ ${UP} == 1 ]; then
+        motor up ${STEPS}
+    fi
 
-if [ ${DOWN}  == 1 ]; then
-    echo "Move down $STEPS"
-    /system/sdcard/bin/motor -d d -s ${STEPS} &>/dev/null
-    sleep ${SLEEP_NUM}
-fi
+    if [ ${DOWN} == 1 ]; then
+        motor down ${STEPS}
+    fi
 
-if [ ${RIGHT} == 1 ]; then
-    echo "Move right $STEPS"
-    /system/sdcard/bin/motor -d r -s ${STEPS} &>/dev/null
-    sleep ${SLEEP_NUM}
-fi
+    if [ ${RIGHT} == 1 ]; then
+        motor right ${STEPS}
+    fi
 
-if [ ${LEFT}  == 1 ]; then
-    echo "Move left $STEPS"
-    /system/sdcard/bin/motor -d l -s ${STEPS} &>/dev/null
-    sleep ${SLEEP_NUM}
-fi
+    if [ ${LEFT} == 1 ]; then
+        motor left $STEPS
+    fi
+) &>/dev/null


### PR DESCRIPTION
When tracking motion we should show the updated value of the axis
on the osd.

I discovered along the way that we already have builtin movement commands
in the common functions which deal with all of this.

Along the way I moved the actual movement to be done in the
background, hoping it might alleviate some of the timeouts seen
when polling every 10 seconds for an image like in home assistant.
Unfortunately, this didnt help. Still leaving it in there as it seems
to me to be correct way of doing this (TM) ;-) .