### PR TITLE
Stop re-write of motion.conf

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -314,8 +314,6 @@ motion_detection(){
     ;;
   off)
     /system/sdcard/bin/setconf -k m -v -1
-    rewrite_config /system/sdcard/config/motion.conf motion_sensitivity "-1"
-
     ;;
   status)
     status=$(/system/sdcard/bin/setconf -g m 2>/dev/null)


### PR DESCRIPTION
Removed line that rewrites "-1" to motion_sensitivity in motion.conf, when using motion_detection "off". Since the motion_detection function pulls motion_sensitivity from the motion.conf file when running motion_detection "on", it will never re-enable motion detection after the first time you disable it since "-1" is written to the motion.conf. #940 