### PR TITLE
Change permissions for saved snapshots and video files.

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -27,12 +27,14 @@ send_matrix=false
 # Snapshots
 save_snapshot=false
 save_dir=/media/motion/stills
+save_snapshot_attr="0666"
 save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"
 max_snapshots=20
 
 # Videos
 save_video=false
 save_video_dir=/media/motion/videos
+save_video_attr="0666"
 video_duration=10
 max_videos=10
 

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -70,7 +70,8 @@ if [ "$save_snapshot" = true ] ; then
 		rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
 	fi
 
-	cp "$snapshot_tempfile" "$save_dir/${snapshot_filename}.jpg"
+	chmod "$save_snapshot_attr" "$snapshot_tempfile"
+	cp -p "$snapshot_tempfile" "$save_dir/${snapshot_filename}.jpg"
 	) &
 fi
 
@@ -88,7 +89,8 @@ if [ "$save_video" = true ] ; then
 		rm -f "$save_video_dir/$(ls -ltr "$save_video_dir" | awk 'NR==2{print $9}')"
 	fi
 
-	cp "$video_tempfile" "$save_video_dir/${snapshot_filename}.mp4"
+	chmod "$save_video_attr" "$video_tempfile"
+	cp -p "$video_tempfile" "$save_video_dir/${snapshot_filename}.mp4"
 	) &
 fi
 


### PR DESCRIPTION
https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/issues/975#issue-420472241

When you use automount to NFSv3, so like this...
mount -o nolock -t nfs 192.168.1.10:/nfs/cams /system/media/nas

You you could not open snapshots from nfs volume. It was have permissions 0600 with "nobody" user.
ls -l /system/media/nas
-rw------- 1 501 1000 162528 Mar 13 13:52 13-03-2019_13.52.49.jpg
-rw------- 1 501 1000 162790 Mar 13 13:53 13-03-2019_13.53.30.jpg
-rw------- 1 501 1000 161054 Mar 13 13:53 13-03-2019_13.53.52.jpg

This commit will correct this problem. 

Setup new variable in /system/sdcard/config/motion.conf.dist will set new permissions for snapshots and videofiles
save_snapshot_attr="0666"
save_video_attr="0666"