### PR TITLE
Fix the files structure in the installation docs

### DIFF
--- a/hacks/install_cfw.md
+++ b/hacks/install_cfw.md
@@ -29,12 +29,12 @@
 It should look like this:
 ```
 E:/
-├── Media
 ├── autoupdate.sh
 ├── bin
 ├── config
 ├── controlscripts
 ├── driver
+├── media
 ├── run.sh
 ├── scripts
 ├── uEnv.bootfromnand.txt


### PR DESCRIPTION
In [this commit](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/commit/3590d169148dcb3ddececb962618ca86d52f7ed9) the `Media` directory was renamed to `media`, so I've updated the installation docs to respect that change. 