### PR TITLE
Fix the "FullHD" FAQ

### DIFF
--- a/hacks/faq.md
+++ b/hacks/faq.md
@@ -23,7 +23,7 @@ No that's not possible. It can be done, but there will be a lot of trouble in do
 
 ### Can I have FullHD resolution?
 
-Yes, but you must flash a custom bootloader to achieve this. 
+Yes, but you must [flash a custom bootloader](/hacks/flashinguboot.md) to achieve this.
 
 ### Can I use USB ethernet cards?
 Yes, just create a usb_eth_driver.conf file in /system/sdcard/config.
@@ -32,8 +32,6 @@ cp /system/sdcard/config/usb_eth_driver.conf.dist /system/sdcard/config/usb_eth_
 reboot
 ```
 If this file exists the run.sh won't start the WIFI driver but instead load the usb ethernet driver. Currently only the asix.ko driver is supported but others can be built.
-
-[Custom Bootloader Installation](/hacks/flashinguboot.md)
 
 ### Which Features does the CFW contain?
 - Full working RTSP with H264/MJPEG. Based on https://github.com/mpromonet/v4l2rtspserver


### PR DESCRIPTION
The "Custom Bootloader Installation" link was moved to an incorrect paragraph in the PR https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/pull/939.

My PR fixes it and also make the link a part of the text.