### PR TITLE
Add fullchain.crt so intermediate CA is sent

### DIFF
--- a/firmware_mod/config/lighttpd.conf.dist
+++ b/firmware_mod/config/lighttpd.conf.dist
@@ -32,6 +32,7 @@ cgi.assign = ( ".cgi" => "/bin/sh" )
 $SERVER["socket"] == ":443" {
   ssl.engine = "enable"
   ssl.pemfile = "/system/sdcard/config/lighttpd.pem"
+  ssl.ca-file = "/system/sdcard/config/fullchain.crt"
 }
 
 


### PR DESCRIPTION
Some clients do not like https://-connection after i started using Lets encrypt (for example, curl).
This is caused by lighttpd not sending the Let's Encrypt CA certificate, so there is no way to verify the certificate:


```
$ openssl s_client -connect camera2.redacted:443 -servername camera2.redacted
CONNECTED(00000003)
depth=0 CN = camera2.redacted
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN = camera2.redacted
verify error:num=21:unable to verify the first certificate
verify return:1
---
Certificate chain
 0 s:/CN=camera2.redacted
   i:/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3
---
```

After specifying `ssl.ca-file` the Let's Encrypt CA cert (cross signed by Digital Signature Trust) is sent as well:
```
$ openssl s_client -connect camera2.redacted:443 -servername camera2.redacted
CONNECTED(00000003)
depth=2 O = Digital Signature Trust Co., CN = DST Root CA X3
verify return:1
depth=1 C = US, O = Let's Encrypt, CN = Let's Encrypt Authority X3
verify return:1
depth=0 CN = camera2.redacted
verify return:1
---
Certificate chain
 0 s:/CN=camera2.redacted
   i:/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3
 1 s:/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3
   i:/O=Digital Signature Trust Co./CN=DST Root CA X3
---
```