### PR TITLE
Motion detectionOn script revamped; Added SMB

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -24,24 +24,34 @@ send_telegram=false
 telegram_alert_type=image
 send_matrix=false
 
+# General
+file_date_pattern="+%d-%m-%Y_%H.%M.%S"
+video_duration=10
+
 # Snapshots
 save_snapshot=false
-save_dir=/media/motion/stills
+save_snapshot_dir=/media/motion/snapshots
 save_snapshot_attr="0666"
-save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"
 max_snapshots=20
 
 # Videos
 save_video=false
 save_video_dir=/media/motion/videos
 save_video_attr="0666"
-video_duration=10
 max_videos=10
+
+# Configure SMB snapshots and videos
+smb_snapshot=false
+smb_video=false
+smb_share="//DEVICE/SHARE"
+smb_username="admin"
+smb_password="admin"
+smb_stills_path="dafang_camera/stills"
+smb_videos_path="dafang_camera/videos"
 
 # Configure FTP snapshots and videos
 ftp_snapshot=false
 ftp_video=false
-ftp_video_duration=10
 ftp_host="ftp.myserver.net"
 ftp_port=21
 ftp_username="user1"

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -43,6 +43,12 @@ video_tempfile=$(mktemp /tmp/video-XXXXXXX)
 filename_pattern="${file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
 filename=$(date "$filename_pattern")
 
+# Turn on the amber led
+if [ "$motion_trigger_led" = true ] ; then
+	debug_msg "Trigger LED"
+	yellow_led on
+fi
+
 # First, take a snapshot (always)
 /system/sdcard/bin/getimage > "$snapshot_tempfile"
 debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
@@ -50,12 +56,6 @@ debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
 # Then, record video (if necessary)
 if [ "$save_video" = true -o "$ftp_video" = true -o "$smb_video" = true -o "$telegram_alert_type" = "video" ] ; then
 	record_video
-fi
-
-# Turn on the amber led
-if [ "$motion_trigger_led" = true ] ; then
-	debug_msg "Trigger LED"
-	yellow_led on
 fi
 
 # Next, start background tasks for all configured notifications


### PR DESCRIPTION
Hi, I've reviewed a little `detectionOn.sh` script and made some cleanups/addons.

This includes:

1. Added SMB upload
There is a native `smbclient` available so we can make use of it to upload files via SMB shares.

2. Revamped FTP upload for a simplified model
I believe "FTP video streaming" is a little overshot and it complicates the script a lot, making a duplicates on video recording. I've simply made it re-use `record_video` function.

3. Made some options generic
Filename pattern and video length had been made generic settings.

4. MQTT snapshot resize and optimization
MQTT max message size is 64KB, but `getimage` often creates bigger files. Especially when using 1080p mod. I added scaling to 1/2 and `jpegoptim` – for MQTT is should be enough for preview purposes.

5. Code cleanup
Some variables were reused not as they were named etc. Cleaned it up.