### PR TITLE
Support for groups and edited messages

### DIFF
--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -43,13 +43,13 @@ imageAlerts() {
 
 respond() {
   case $1 in
-    /mem) sendMem;;
-    /shot) sendShot;;
-    /on) detectionOn;;
-    /off) detectionOff;;
-    /textalerts) textAlerts;;
-    /imagealerts) imageAlerts;;
-    /help) $TELEGRAM m "######### Bot commands #########\n# /mem - show memory information\n# /shot - take a shot\n# /on - motion detect on\n# /off - motion detect off\n# /textalerts - Text alerts on motion detection\n# /imagealerts - Image alerts on motion detection";;
+    /mem*) sendMem;;
+    /shot*) sendShot;;
+    /on*) detectionOn;;
+    /off*) detectionOff;;
+    /textalerts*) textAlerts;;
+    /imagealerts*) imageAlerts;;
+    /help*) $TELEGRAM m "######### Bot commands #########\n# /mem - show memory information\n# /shot - take a shot\n# /on - motion detect on\n# /off - motion detect off\n# /textalerts - Text alerts on motion detection\n# /imagealerts - Image alerts on motion detection";;
     *) $TELEGRAM m "I can't respond to '$1' command"
   esac
 }

--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -75,15 +75,19 @@ main() {
     return 0
   fi;
 
-  chatId=$(echo "$json" | $JQ -r '.result[0].message.chat.id // ""')
+  messageAttr="message"
+  messageVal=$(echo "$json" | $JQ -r '.result[0].message // ""')
+  [ -z "$messageVal" ] && messageAttr="edited_message"
+
+  chatId=$(echo "$json" | $JQ -r ".result[0].$messageAttr.chat.id // \"\"")
   [ -z "$chatId" ] && return 0 # no new messages
 
-  cmd=$(echo "$json" | $JQ -r '.result[0].message.text // ""')
+  cmd=$(echo "$json" | $JQ -r ".result[0].$messageAttr.text // \"\"")
   updateId=$(echo "$json" | $JQ -r '.result[0].update_id // ""')
 
   if [ "$chatId" != "$userChatId" ]; then
-    username=$(echo "$json" | $JQ -r '.result[0].message.from.username // ""')
-    firstName=$(echo "$json" | $JQ -r '.result[0].message.from.first_name // ""')
+    username=$(echo "$json" | $JQ -r ".result[0].$messageAttr.from.username // \"\"")
+    firstName=$(echo "$json" | $JQ -r ".result[0].$messageAttr.from.first_name // \"\"")
     $TELEGRAM m "Received message from not authrized chat: $chatId\nUser: $username($firstName)\nMessage: $cmd"
   else
     respond $cmd


### PR DESCRIPTION
1. When bot is added to a group it receives commands like /command@botname instead of '/command' in direct chats.  Commit 4861496 allow bot to understand such commands.

2. When user edit message in telegram it comes to bot with unexpected json structure. This hangs up message processing at all. Commit de2bea6 add support for 'edited_message' processing.
