### PR TITLE
Load `motion_timeout` setting from sdcard

### DIFF
--- a/firmware_mod/controlscripts/configureMotion
+++ b/firmware_mod/controlscripts/configureMotion
@@ -15,4 +15,5 @@ if [ -f /system/sdcard/config/motion.conf ] ; then
     fi
     /system/sdcard/bin/setconf -k z -v ${motion_indicator_color} 2>/dev/null
     /system/sdcard/bin/setconf -k t -v ${motion_tracking} 2>/dev/null
+    /system/sdcard/bin/setconf -k u -v ${motion_timeout} 2>/dev/null
 fi;


### PR DESCRIPTION
Currently, restarting the camera will cause the `motion_timeout` setting to be defaulted to the last value. I think a call to set the config value in `configureMotion` was missed.