### PR TITLE
add possibility to disable wifi with a HTTP call

### DIFF
--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -600,6 +600,11 @@ if [ -n "$F_cmd" ]; then
           return
           ;;
 
+       disable_wifi)
+          ifconfig wlan0 down
+          return
+          ;;
+
      *)
         echo "Unsupported command '$F_cmd'"
         ;;


### PR DESCRIPTION
This PR adds a HTTP action to disable the wifi, e.g. at night.
You should make a cronjob to enable the wifi automatically later, e.g.:

```
0    7    *    *    *    /system/sdcard/bin/busybox ifconfig wlan0 up && udhcpc -i wlan0 renew
```