### PR TITLE
remove pid file for recording even if kill failed

### DIFF
--- a/firmware_mod/controlscripts/recording
+++ b/firmware_mod/controlscripts/recording
@@ -40,7 +40,8 @@ stop()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
   if [ "$pid" ]; then
-    kill "$pid" &&  rm "$PIDFILE"
+    kill "$pid"
+    rm "$PIDFILE" 1> /dev/null 2>&1
     echo "Stopped recording."
   else
     echo "Could not find a running recording to stop."


### PR DESCRIPTION
There is an issue if the recording process died the stop command will not remove the pid file, and will prevent the start command from being run. 
I copy this code from https://github.com/chaoranxie/Xiaomi-Dafang-Hacks/blob/master/firmware_mod/controlscripts/rtsp-h264#L100