### PR TITLE
 allow recording with credentials

### DIFF
--- a/firmware_mod/controlscripts/recording
+++ b/firmware_mod/controlscripts/recording
@@ -7,7 +7,7 @@ fi
 
 ## UserName and password
 if [ "$USERNAME" != "" ]; then
-    CREDENTIAL="$USERNAME:$USERPASSWORD@"
+    CREDENTIALS="$USERNAME:$USERPASSWORD@"
 fi
 
 if [ ! -d "$DCIM_PATH" ]; then
@@ -39,7 +39,7 @@ start()
     do
       sleep 1
     done
-    /system/sdcard/bin/busybox nohup /system/sdcard/bin/avconv -flags low_delay -fflags nobuffer -probesize 32 -i rtsp://"$CREDENTIAL"0.0.0.0:8554/unicast -strict experimental -y -vcodec copy -an $RECORDING_PATH &>/dev/null &
+    /system/sdcard/bin/busybox nohup /system/sdcard/bin/avconv -flags low_delay -fflags nobuffer -probesize 32 -i rtsp://"$CREDENTIALS"0.0.0.0:8554/unicast -strict experimental -y -vcodec copy -an $RECORDING_PATH &>/dev/null &
     echo "$!" > "$PIDFILE"
   fi
 }


### PR DESCRIPTION
if user uses username and password for the rtsp, then recording will fail. this fixes that