### PR TITLE
Fix for exposure (isp_exposure)

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -236,7 +236,7 @@ ldr(){
 exposure(){
   case "$1" in
   status)
-    isp_exposure=$(grep -oP '(?<=ISP exposure log2 id: )[0-9]+' /proc/jz/isp/isp_info)
+    isp_exposure=$(grep 'ISP exposure log2 id:' /proc/jz/isp/isp_info  | sed 's/^.*: //')
     echo "$isp_exposure"
   esac
 }


### PR DESCRIPTION
-P option is not available on the system, so let's use this (tested on the cam, too).

![image](https://user-images.githubusercontent.com/3549445/64880626-ed681c00-d658-11e9-91bb-0ad8cf526fe6.png)

```
[root@DAFANG:~]# grep 'ISP exposure log2 id:' /proc/jz/isp/isp_info  | sed 's/^.*: //'
889555
```

At the first time, i totally forgot to test that part.