### PR TITLE
Fixed chicago timezone

### DIFF
--- a/firmware_mod/www/timezones.tsv
+++ b/firmware_mod/www/timezones.tsv
@@ -81,7 +81,7 @@ America/Cancun	CST6CDT,M4.1.0,M10.5.0
 America/Caracas	VET4:30
 America/Cayenne	GFT3
 America/Cayman	EST5
-America/Chicago	CST6CDT,M3.2.0,M11.1.0
+America/Chicago	CST6CDT
 America/Chihuahua	MST7MDT,M4.1.0,M10.5.0
 America/Costa_Rica	CST6
 America/Cuiaba	AMT4AMST,M10.3.0/0,M2.3.0/0


### PR DESCRIPTION
It appears the customized POSIX formats do not work on this device (tested with `DAFANG`).  Changing the time zone to `America/Chicago` had no effect on the OSD.  When I removed the customized portion of the format it was resolved.  I'd suggest removing the rest of the customized formats but I wasn't planning to test them all so figured I'd just fix the one I know about.