### PR TITLE
detectionOn code cleanup and unification

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -24,24 +24,25 @@ send_telegram=false
 telegram_alert_type=image
 send_matrix=false
 
+# General
+file_date_pattern="+%d-%m-%Y_%H.%M.%S"
+video_duration=10
+
 # Snapshots
 save_snapshot=false
-save_dir=/system/sdcard/DCIM/motion/stills
+save_snapshot_dir=/system/sdcard/DCIM/motion/stills
 save_snapshot_attr="0666"
-save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"
 max_snapshots=20
 
 # Videos
 save_video=false
 save_video_dir=/system/sdcard/DCIM/motion/videos
 save_video_attr="0666"
-video_duration=10
 max_videos=10
 
 # Configure FTP snapshots and videos
 ftp_snapshot=false
 ftp_video=false
-ftp_video_duration=10
 ftp_host="ftp.myserver.net"
 ftp_port=21
 ftp_username="user1"

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -35,12 +35,21 @@ record_video () {
 	fi
 }
 
-# First, take a snapshot and record date ASAP
+# Turn on the amber led
+if [ "$motion_trigger_led" = true ] ; then
+	debug_msg "Trigger LED"
+	yellow_led on
+fi
+
+# Prepare temp files
 snapshot_tempfile=$(mktemp /tmp/snapshot-XXXXXXX)
 video_tempfile=$(mktemp /tmp/video-XXXXXXX)
 
-snapshot_pattern="${save_file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
-snapshot_filename=$(date "$snapshot_pattern")
+# Prepare filename, save datetime ASAP
+filename_pattern="${file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
+filename=$(date "$filename_pattern")
+
+# First, take a snapshot (always)
 /system/sdcard/bin/getimage > "$snapshot_tempfile"
 debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
 
@@ -59,26 +68,26 @@ fi
 # Save a snapshot
 if [ "$save_snapshot" = true ] ; then
 	(
-	debug_msg "Save snapshot to $save_dir/${snapshot_filename}.jpg"
+	debug_msg "Save snapshot to $save_snapshot_dir/${filename}.jpg"
 
-	if [ ! -d "$save_dir" ]; then
-		mkdir -p "$save_dir"
+	if [ ! -d "$save_snapshot_dir" ]; then
+		mkdir -p "$save_snapshot_dir"
 	fi
 
 	# Limit the number of snapshots
-	if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
-		rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
+	if [ "$(ls "$save_snapshot_dir" | wc -l)" -ge "$max_snapshots" ]; then
+		rm -f "$save_snapshot_dir/$(ls -ltr "$save_snapshot_dir" | awk 'NR==2{print $9}')"
 	fi
 
 	chmod "$save_snapshot_attr" "$snapshot_tempfile"
-	cp -p "$snapshot_tempfile" "$save_dir/${snapshot_filename}.jpg"
+	cp -p "$snapshot_tempfile" "$save_snapshot_dir/${filename}.jpg"
 	) &
 fi
 
 # Save the video
 if [ "$save_video" = true ] ; then
 	(
-	debug_msg "Save video to $save_video_dir/${snapshot_filename}.mp4"
+	debug_msg "Save video to $save_video_dir/${filename}.mp4"
 
 	if [ ! -d "$save_video_dir" ]; then
 		mkdir -p "$save_video_dir"
@@ -90,7 +99,7 @@ if [ "$save_video" = true ] ; then
 	fi
 
 	chmod "$save_video_attr" "$video_tempfile"
-	cp -p "$video_tempfile" "$save_video_dir/${snapshot_filename}.mp4"
+	cp -p "$video_tempfile" "$save_video_dir/${filename}.mp4"
 	) &
 fi
 
@@ -116,8 +125,8 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 	fi
 
 	if [ "$ftp_snapshot" = true ]; then
-		debug_msg "Send FTP snapshot to $ftpput_url/$ftp_stills_dir/${snapshot_filename}.jpg"
-		$ftpput_cmd "$ftp_stills_dir/${snapshot_filename}.jpg" "$snapshot_tempfile"
+		debug_msg "Send FTP snapshot to $ftpput_url/$ftp_stills_dir/${filename}.jpg"
+		$ftpput_cmd "$ftp_stills_dir/${filename}.jpg" "$snapshot_tempfile"
 	fi
 
 	if [ "$ftp_video" = true ]; then
@@ -130,7 +139,7 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 		exec 5<> /run/ftp_motion_video_stream.flock
 		if /system/sdcard/bin/busybox flock -n -x 5; then
 			# Got the lock
-			debug_msg "Begin FTP video stream to $ftpput_url/$ftp_videos_dir/${snapshot_filename}.avi for $ftp_video_duration seconds"
+			debug_msg "Begin FTP video stream to $ftpput_url/$ftp_videos_dir/${filename}.avi for $video_duration seconds"
 
 			# XXX Uses avconv to stitch multiple JPEGs into 1fps video.
 			#  I couldn't get it working another way. /dev/videoX inputs
@@ -138,14 +147,14 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 			#  start streaming and gets flaky when when memory or cpu
 			#  are pegged. This is a clugy method, but works well even
 			# at high res, fps, cpu, and memory load!
-			( while [ "$(/system/sdcard/bin/busybox date "+%s")" -le "$(/system/sdcard/bin/busybox expr "$(/system/sdcard/bin/busybox stat -c "%X" /run/ftp_motion_video_stream.flock)" + "$ftp_video_duration")" ]; do
+			( while [ "$(/system/sdcard/bin/busybox date "+%s")" -le "$(/system/sdcard/bin/busybox expr "$(/system/sdcard/bin/busybox stat -c "%X" /run/ftp_motion_video_stream.flock)" + "$video_duration")" ]; do
 					/system/sdcard/bin/getimage
 					sleep 1
 				done ) \
 			| /system/sdcard/bin/avconv -analyzeduration 0 -f image2pipe -r 1 -c:v mjpeg -c:a none -i - -c:v copy -c:a none -f avi - 2>/dev/null \
-			| $ftpput_cmd "$ftp_videos_dir/${snapshot_filename}.avi" - &
+			| $ftpput_cmd "$ftp_videos_dir/${filename}.avi" - &
 		else
-			debug_msg "FTP video stream already running, continued another $ftp_video_duration seconds"
+			debug_msg "FTP video stream already running, continued another $video_duration seconds"
 		fi
 
 		# File descriptor 5 is inherited across fork to preserve lock,


### PR DESCRIPTION
Unification of config in motion.conf and detectionOn:

* Extracted single `video_duration` instead of multiple ones
* Renamed `save_dir` -> `save_snapshot_dir` to match `save_video_dir `
* `snapshot_filename` was used as filename also for videos etc. Therefore renamed to `filename`.