### PR TITLE
Master smb

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -49,3 +49,12 @@ ftp_username="user1"
 ftp_password="password2"
 ftp_stills_dir="motion/stills"
 ftp_videos_dir="motion/videos"
+
+# Configure SMB snapshots and videos
+smb_snapshot=false
+smb_video=false
+smb_share="//DEVICE/SHARE"
+smb_username="admin"
+smb_password="admin"
+smb_stills_path="dafang_camera/stills"
+smb_videos_path="dafang_camera/videos"

--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -24,24 +24,25 @@ send_telegram=false
 telegram_alert_type=image
 send_matrix=false
 
+# General
+file_date_pattern="+%d-%m-%Y_%H.%M.%S"
+video_duration=10
+
 # Snapshots
 save_snapshot=false
-save_dir=/system/sdcard/DCIM/motion/stills
+save_snapshot_dir=/system/sdcard/DCIM/motion/stills
 save_snapshot_attr="0666"
-save_file_date_pattern="+%d-%m-%Y_%H.%M.%S"
 max_snapshots=20
 
 # Videos
 save_video=false
 save_video_dir=/system/sdcard/DCIM/motion/videos
 save_video_attr="0666"
-video_duration=10
 max_videos=10
 
 # Configure FTP snapshots and videos
 ftp_snapshot=false
 ftp_video=false
-ftp_video_duration=10
 ftp_host="ftp.myserver.net"
 ftp_port=21
 ftp_username="user1"

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -35,12 +35,21 @@ record_video () {
 	fi
 }
 
-# First, take a snapshot and record date ASAP
+# Turn on the amber led
+if [ "$motion_trigger_led" = true ] ; then
+	debug_msg "Trigger LED"
+	yellow_led on
+fi
+
+# Prepare temp files
 snapshot_tempfile=$(mktemp /tmp/snapshot-XXXXXXX)
 video_tempfile=$(mktemp /tmp/video-XXXXXXX)
 
-snapshot_pattern="${save_file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
-snapshot_filename=$(date "$snapshot_pattern")
+# Prepare filename, save datetime ASAP
+filename_pattern="${file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
+filename=$(date "$filename_pattern")
+
+# First, take a snapshot (always)
 /system/sdcard/bin/getimage > "$snapshot_tempfile"
 debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
 
@@ -59,26 +68,26 @@ fi
 # Save a snapshot
 if [ "$save_snapshot" = true ] ; then
 	(
-	debug_msg "Save snapshot to $save_dir/${snapshot_filename}.jpg"
+	debug_msg "Save snapshot to $save_snapshot_dir/${filename}.jpg"
 
-	if [ ! -d "$save_dir" ]; then
-		mkdir -p "$save_dir"
+	if [ ! -d "$save_snapshot_dir" ]; then
+		mkdir -p "$save_snapshot_dir"
 	fi
 
 	# Limit the number of snapshots
-	if [ "$(ls "$save_dir" | wc -l)" -ge "$max_snapshots" ]; then
-		rm -f "$save_dir/$(ls -ltr "$save_dir" | awk 'NR==2{print $9}')"
+	if [ "$(ls "$save_snapshot_dir" | wc -l)" -ge "$max_snapshots" ]; then
+		rm -f "$save_snapshot_dir/$(ls -ltr "$save_snapshot_dir" | awk 'NR==2{print $9}')"
 	fi
 
 	chmod "$save_snapshot_attr" "$snapshot_tempfile"
-	cp -p "$snapshot_tempfile" "$save_dir/${snapshot_filename}.jpg"
+	cp -p "$snapshot_tempfile" "$save_snapshot_dir/${filename}.jpg"
 	) &
 fi
 
 # Save the video
 if [ "$save_video" = true ] ; then
 	(
-	debug_msg "Save video to $save_video_dir/${snapshot_filename}.mp4"
+	debug_msg "Save video to $save_video_dir/${filename}.mp4"
 
 	if [ ! -d "$save_video_dir" ]; then
 		mkdir -p "$save_video_dir"
@@ -90,7 +99,7 @@ if [ "$save_video" = true ] ; then
 	fi
 
 	chmod "$save_video_attr" "$video_tempfile"
-	cp -p "$video_tempfile" "$save_video_dir/${snapshot_filename}.mp4"
+	cp -p "$video_tempfile" "$save_video_dir/${filename}.mp4"
 	) &
 fi
 
@@ -116,8 +125,8 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 	fi
 
 	if [ "$ftp_snapshot" = true ]; then
-		debug_msg "Send FTP snapshot to $ftpput_url/$ftp_stills_dir/${snapshot_filename}.jpg"
-		$ftpput_cmd "$ftp_stills_dir/${snapshot_filename}.jpg" "$snapshot_tempfile"
+		debug_msg "Send FTP snapshot to $ftpput_url/$ftp_stills_dir/${filename}.jpg"
+		$ftpput_cmd "$ftp_stills_dir/${filename}.jpg" "$snapshot_tempfile"
 	fi
 
 	if [ "$ftp_video" = true ]; then
@@ -130,7 +139,7 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 		exec 5<> /run/ftp_motion_video_stream.flock
 		if /system/sdcard/bin/busybox flock -n -x 5; then
 			# Got the lock
-			debug_msg "Begin FTP video stream to $ftpput_url/$ftp_videos_dir/${snapshot_filename}.avi for $ftp_video_duration seconds"
+			debug_msg "Begin FTP video stream to $ftpput_url/$ftp_videos_dir/${filename}.avi for $video_duration seconds"
 
 			# XXX Uses avconv to stitch multiple JPEGs into 1fps video.
 			#  I couldn't get it working another way. /dev/videoX inputs
@@ -138,14 +147,14 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 			#  start streaming and gets flaky when when memory or cpu
 			#  are pegged. This is a clugy method, but works well even
 			# at high res, fps, cpu, and memory load!
-			( while [ "$(/system/sdcard/bin/busybox date "+%s")" -le "$(/system/sdcard/bin/busybox expr "$(/system/sdcard/bin/busybox stat -c "%X" /run/ftp_motion_video_stream.flock)" + "$ftp_video_duration")" ]; do
+			( while [ "$(/system/sdcard/bin/busybox date "+%s")" -le "$(/system/sdcard/bin/busybox expr "$(/system/sdcard/bin/busybox stat -c "%X" /run/ftp_motion_video_stream.flock)" + "$video_duration")" ]; do
 					/system/sdcard/bin/getimage
 					sleep 1
 				done ) \
 			| /system/sdcard/bin/avconv -analyzeduration 0 -f image2pipe -r 1 -c:v mjpeg -c:a none -i - -c:v copy -c:a none -f avi - 2>/dev/null \
-			| $ftpput_cmd "$ftp_videos_dir/${snapshot_filename}.avi" - &
+			| $ftpput_cmd "$ftp_videos_dir/${filename}.avi" - &
 		else
-			debug_msg "FTP video stream already running, continued another $ftp_video_duration seconds"
+			debug_msg "FTP video stream already running, continued another $video_duration seconds"
 		fi
 
 		# File descriptor 5 is inherited across fork to preserve lock,

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -53,7 +53,8 @@ filename=$(date "$filename_pattern")
 /system/sdcard/bin/getimage > "$snapshot_tempfile"
 debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
 
-if [ "$save_video" = true  ] || [ "$telegram_alert_type" = "video" ] ; then
+# Then, record video (if necessary)
+if [ "$save_video" = true -o "$smb_video" = true -o "$telegram_alert_type" = "video" ] ; then
 	record_video
 fi
 
@@ -107,10 +108,8 @@ fi
 if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 	(
 	ftpput_cmd="/system/sdcard/bin/busybox ftpput"
-	ftpput_url="ftp://"
 	if [ "$ftp_username" != "" ]; then
 		ftpput_cmd="$ftpput_cmd -u $ftp_username"
-		ftpput_url="${ftpput_url}${ftp_username}@"
 	fi
 	if [ "$ftp_password" != "" ]; then
 		ftpput_cmd="$ftpput_cmd -p $ftp_password"
@@ -119,13 +118,9 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 		ftpput_cmd="$ftpput_cmd -P $ftp_port"
 	fi
 	ftpput_cmd="$ftpput_cmd $ftp_host"
-	ftpput_url="${ftpput_url}${ftp_host}"
-	if [ "$ftp_port" != "" ]; then
-		ftpput_url="${ftpput_url}:$ftp_port"
-	fi
 
 	if [ "$ftp_snapshot" = true ]; then
-		debug_msg "Send FTP snapshot to $ftpput_url/$ftp_stills_dir/${filename}.jpg"
+		debug_msg "Sending FTP snapshot to ftp://$ftp_host/$ftp_stills_dir/${filename}.jpg"
 		$ftpput_cmd "$ftp_stills_dir/${filename}.jpg" "$snapshot_tempfile"
 	fi
 
@@ -139,7 +134,7 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 		exec 5<> /run/ftp_motion_video_stream.flock
 		if /system/sdcard/bin/busybox flock -n -x 5; then
 			# Got the lock
-			debug_msg "Begin FTP video stream to $ftpput_url/$ftp_videos_dir/${filename}.avi for $video_duration seconds"
+			debug_msg "Begin FTP video stream to ftp://$ftp_host/$ftp_videos_dir/${filename}.avi for $video_duration seconds"
 
 			# XXX Uses avconv to stitch multiple JPEGs into 1fps video.
 			#  I couldn't get it working another way. /dev/videoX inputs
@@ -162,6 +157,34 @@ if [ "$ftp_snapshot" = true -o "$ftp_video" = true ]; then
 		exec 5>&-
 	fi
 	) &
+fi
+
+# SMB snapshot and video
+if [ "$smb_snapshot" = true -o "$smb_video" = true ]; then
+    (
+    smbclient_cmd="/system/bin/smbclient $smb_share"
+    if [ "$smb_password" != "" ]; then
+        smbclient_cmd="$smbclient_cmd $smb_password"
+    else
+        smbclient_cmd="$smbclient_cmd -N"
+    fi
+    if [ "$smb_username" != "" ]; then
+        smbclient_cmd="$smbclient_cmd -U $smb_username"
+    fi
+
+    # Save snapshot
+    if [ "$smb_snapshot" = true ]; then
+        debug_msg "Saving SMB snapshot to $smb_share/$smb_stills_path"
+        snapshot_tempfilename=${snapshot_tempfile:5}
+        $smbclient_cmd -D "$smb_stills_path" -c "lcd /tmp; put $snapshot_tempfilename; rename $snapshot_tempfilename ${filename}.jpg"
+    fi
+    # Save video
+    if [ "$smb_video" = true ]; then
+        debug_msg "Saving SMB video to $smb_share/$smb_videos_path"
+        video_tempfilename=${video_tempfile:5}
+        $smbclient_cmd -D "$smb_videos_path" -c "lcd /tmp; put $video_tempfilename; rename $video_tempfilename ${filename}.mp4"
+    fi
+    ) &
 fi
 
 # Publish a mqtt message


### PR DESCRIPTION
*Requires #1191 merged first (this PR includes it).*

Added SMB still/video upload thanks to built-in `smbclient`.

Additionally:
Removed `$ftpput_url` creation as it was used just for logging purposes and potentially exposed credentials. Logging with `ftp://$ftp_host/...` is perfectly enough for debug purposes.