### PR TITLE
Turn on amber LED before record; mqtt-control play sound

### DIFF
--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -35,6 +35,12 @@ record_video () {
 	fi
 }
 
+# Turn on the amber led
+if [ "$motion_trigger_led" = true ] ; then
+	debug_msg "Trigger LED"
+	yellow_led on
+fi
+
 # First, take a snapshot and record date ASAP
 snapshot_tempfile=$(mktemp /tmp/snapshot-XXXXXXX)
 video_tempfile=$(mktemp /tmp/video-XXXXXXX)
@@ -46,12 +52,6 @@ debug_msg "Got snapshot_tempfile=$snapshot_tempfile"
 
 if [ "$save_video" = true  ] || [ "$telegram_alert_type" = "video" ] ; then
 	record_video
-fi
-
-# Turn on the amber led
-if [ "$motion_trigger_led" = true ] ; then
-	debug_msg "Trigger LED"
-	yellow_led on
 fi
 
 # Next, start background tasks for all configured notifications

--- a/firmware_mod/scripts/mqtt-control.sh
+++ b/firmware_mod/scripts/mqtt-control.sh
@@ -19,6 +19,13 @@ killall mosquitto_sub.bin 2> /dev/null
       /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/ ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(/system/sdcard/scripts/mqtt-status.sh)"
     ;;
 
+    "${TOPIC}/play "*)
+      AUDIOFILE=$(echo "$line" | awk '{print $2}')
+      VOLUME=$(echo "$line" | awk '{print $3}')
+      VOLUME=${VOLUME:-50}
+      /system/sdcard/bin/audioplay "/system/sdcard/media/$AUDIOFILE" "$VOLUME" $
+    ;;
+
     "${TOPIC}/leds/blue")
       /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/leds/blue ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(blue_led status)"
     ;;


### PR DESCRIPTION
PR with two things:

Amber LED should turn on before record has started.
Added mqtt-control to play sound from `/system/sdcard/media/` – useful when controlling camera with MQTT, i.e. can play alarm sound from MQTT Alarm.