### PR TITLE
Fixed new stills/video target dir creation

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -40,13 +40,13 @@ video_rtsp_f=15
 save_snapshot=false
 save_snapshot_dir=/system/sdcard/DCIM/motion/stills
 save_snapshot_attr="0666"
-max_snapshots=20
+max_snapshot_days=20
 
 # Videos
 save_video=false
 save_video_dir=/system/sdcard/DCIM/motion/videos
 save_video_attr="0666"
-max_videos=10
+max_video_days=10
 
 # Configure FTP snapshots and videos
 ftp_snapshot=false

--- a/firmware_mod/controlscripts/mqtt-control
+++ b/firmware_mod/controlscripts/mqtt-control
@@ -34,7 +34,6 @@ start()
 stop()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
-  current=$(status)
   if [ "$pid" ]; then
     kill "$pid"
     rm "$PIDFILE" 1> /dev/null 2>&1

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -72,12 +72,12 @@ if [ "$save_snapshot" = true ] ; then
 	(
 	debug_msg "Save snapshot to $save_snapshot_dir/$groupname/$filename.jpg"
 
-	if [ ! -d "$save_snapshot_dir" ]; then
-		mkdir -p "$save_snapshot_dir"
+	if [ ! -d "$save_snapshot_dir/$groupname" ]; then
+		mkdir -p "$save_snapshot_dir/$groupname"
 	fi
 
 	# Limit the number of snapshots
-	if [ "$(ls "$save_snapshot_dir" | wc -l)" -ge "$max_snapshots" ]; then
+	if [ "$(ls "$save_snapshot_dir" | wc -l)" -ge "$max_snapshot_days" ]; then
 		rm -f "$save_snapshot_dir/$(ls -ltr "$save_snapshot_dir" | awk 'NR==2{print $9}')"
 	fi
 
@@ -91,12 +91,12 @@ if [ "$save_video" = true ] ; then
 	(
 	debug_msg "Save video to $save_video_dir/$groupname/$filename.mp4"
 
-	if [ ! -d "$save_video_dir" ]; then
-		mkdir -p "$save_video_dir"
+	if [ ! -d "$save_video_dir/$groupname" ]; then
+		mkdir -p "$save_video_dir/$groupname"
 	fi
 
 	# Limit the number of videos
-	if [ "$(ls "$save_video_dir" | wc -l)" -ge "$max_videos" ]; then
+	if [ "$(ls "$save_video_dir" | wc -l)" -ge "$max_video_days" ]; then
 		rm -f "$save_video_dir/$(ls -ltr "$save_video_dir" | awk 'NR==2{print $9}')"
 	fi
 


### PR DESCRIPTION
Creation of `yyyy-mm-dd` in target derectories for stills and video was not amended. Fixed.