### PR TITLE
Support authenticated RTSP for record_video

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -35,6 +35,9 @@ video_use_rtsp=true
 video_rtsp_w=1280
 video_rtsp_h=720
 video_rtsp_f=15
+# Uncomment these with appropriate values from rtspserver.conf if set there
+#video_rtsp_username="user1"
+#video_rtsp_password="password2"
 
 # Snapshots
 save_snapshot=false

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -23,7 +23,11 @@ record_video () {
 		debug_msg "Begin recording to $video_tempfile for $video_duration seconds"
 
         if [ "$video_use_rtsp" = true ]; then
-            /system/sdcard/bin/openRTSP -4 -w "$video_rtsp_w" -h "$video_rtsp_h" -f "$video_rtsp_f" -d "$video_duration" rtsp://127.0.0.1:8554/unicast > "$video_tempfile"
+            rtsp_cmd="/system/sdcard/bin/openRTSP -4"
+            if [ -n "$video_rtsp_username" ]; then
+                rtsp_cmd="$rtsp_cmd -u $video_rtsp_username $video_rtsp_password"
+            fi
+            $rtsp_cmd -w "$video_rtsp_w" -h "$video_rtsp_h" -f "$video_rtsp_f" -d "$video_duration" rtsp://127.0.0.1:8554/unicast > "$video_tempfile"
         else
             # Use avconv to stitch multiple JPEGs into 1fps video.
             # I couldn't get it working another way.


### PR DESCRIPTION
Using openrtsp (since #1195) doesn't currently work with authenticated RTSP streams. If you set `$video_use_rtsp = true` when RTSP requires credentials, then it doesn't record the stream. (It does throw an auth error, but this is normally invisible.)

This PR adds basic support for passing through credentials. You have to manually add them to _motion.conf_, duplicating what's in _rtspserver.conf_ but, as far as I can tell, using openrtsp currently requires manual edits to that conf file anyway.