### PR TITLE
Update tinycam.md to include official instructions

### DIFF
--- a/integration/tinycam/tinycam.md
+++ b/integration/tinycam/tinycam.md
@@ -1,5 +1,20 @@
 ## Integration in tinyCam
+As of tinyCam Version [10.2](https://tinycammonitor.com/changelog.html) a "Xiaomi Dafang" camera has been added, it
+includes support for Xiaomi-Dafang-Hacks.
 
+1. Make sure you have the user 'root' and same password set for both HTTPS and RTSP.
+2. Open tinyCam and go to Manage Cameras > + > Add IP camera, NVR/DVR
+3. Fill out the following settings:
+   * Camera Brand: Xiaomi
+   * Camera Model: Dafang
+   * Hostname/IP address: <IP_address/hostname>
+   * RTSP port number: 8554
+   * Use HTTPS: selected
+   * Username: root
+   * Password: ismart12 (we recommend changing the default password)
+4. Click Camera Status to verify the settings are correct.
+  
+### Old Method Using Custom Vendor File
 1. Make sure you have the user 'root' and same password set for both HTTPS and RTSP.
 2. Download the [custom_vendors.xml](custom_vendors.xml) configuration file.
 3. Open tinyCam and go to settings -> Developer Settings -> Custom brand XML file -> Choose custom_vendors.xml
@@ -8,7 +23,7 @@
 
 Note: A Custom_vendors.xml 'file not found' error can happen due to tinyCam not taking the correct path from file manager. Make sure it is not prefixed with document etc.
 
-### tinyCam camera settings (with custom_vendor.xml loaded)
+#### tinyCam camera settings (with custom_vendor.xml loaded)
 
 Web port number: 443
 
@@ -18,7 +33,7 @@ RTSP port number: 8554
 
 Use HTTPS: ticked
 
-### For audio support add the following to your rtspserver.conf
+#### For audio support add the following to your rtspserver.conf
 
 AUDIOFORMAT=PCMU
 

--- a/integration/tinycam/tinycam.md
+++ b/integration/tinycam/tinycam.md
@@ -14,25 +14,6 @@ includes support for Xiaomi-Dafang-Hacks.
    * Password: ismart12 (we recommend changing the default password)
 4. Click Camera Status to verify the settings are correct.
   
-### Old Method Using Custom Vendor File
-1. Make sure you have the user 'root' and same password set for both HTTPS and RTSP.
-2. Download the [custom_vendors.xml](custom_vendors.xml) configuration file.
-3. Open tinyCam and go to settings -> Developer Settings -> Custom brand XML file -> Choose custom_vendors.xml
-4. Restart tinyCam
-5. Run tinyCam and select Brand -> XiaomiHacks and Model -> Dafang
-
-Note: A Custom_vendors.xml 'file not found' error can happen due to tinyCam not taking the correct path from file manager. Make sure it is not prefixed with document etc.
-
-#### tinyCam camera settings (with custom_vendor.xml loaded)
-
-Web port number: 443
-
-Protocol: RTSP over TCP (MPEG/H264/H265)
-
-RTSP port number: 8554
-
-Use HTTPS: ticked
-
 #### For audio support add the following to your rtspserver.conf
 
 AUDIOFORMAT=PCMU


### PR DESCRIPTION
Since tinyCam version 10.2 there is a Xiaomi Dafang camera that can be used, therefore eliminating the need for custom_vendors.xml.

I left the custom_vendors.xml instructions in case someone needs it, but I'm not opposed to removing it.