### PR TITLE
Add extra status code to rtsp-h264

### DIFF
--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -24,6 +24,8 @@ status()
   if [ "$pid" ]; then
     # Prints PID: $pid if exists and returns 0(no error) else returns 1(error condition)
     kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
+  else
+    return 2
   fi
 }
 

--- a/firmware_mod/controlscripts/rtsp-h264
+++ b/firmware_mod/controlscripts/rtsp-h264
@@ -22,9 +22,11 @@ status()
 {
   pid="$(cat "$PIDFILE" 2>/dev/null)"
   if [ "$pid" ]; then
-    # Prints PID: $pid if exists and returns 0(no error) else returns 1(error condition)
+    # return current pid if pidfile exists and contained pid is alive
+    # return 1 if pidfile existed but the contained pid is dead
     kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
   else
+    # return 2 if pidfile did not exist
     return 2
   fi
 }


### PR DESCRIPTION
I created a cron watchdog script and when the pidfile was missing status() was returning 0. I made it return 2 in this case. This makes my script work as intended.