### PR TITLE
Disabling SSL / path corrections / misc changes

### DIFF
--- a/firmware_mod/config/lighttpd.conf.dist
+++ b/firmware_mod/config/lighttpd.conf.dist
@@ -27,13 +27,13 @@ server.modules = ("mod_auth",
 
 cgi.assign = ( ".cgi" => "/bin/sh" )
 
-
-
+#If below 4 lines are commented out then SSL is disabled if un-commented SSL is enabled
+#SSL is enabled by default
+#If disabling SSL you must clear your site cookie
 $SERVER["socket"] == ":443" {
   ssl.engine = "enable"
   ssl.pemfile = "/system/sdcard/config/lighttpd.pem"
 }
-
 
 # Support letsencrypt SSL cert paths
 # (we don't want to upgrade to SSL nor auth' this path)
@@ -43,6 +43,9 @@ $HTTP["url"] !~ "^/.well-known/(.*)" {
     auth.backend.htdigest.userfile = "/system/sdcard/config/lighttpd.user"
     auth.require = ( "/" => ("method" => "basic", "realm" => "all", "require" => "user=root"))
 
+#If below 7 lines are commented out then SSL is disabled if un-commented SSL is enabled
+#SSL is enabled by default
+#If disabling SSL you must clear your site cookie
     $HTTP["scheme"] == "http" {
         # capture vhost name with regex conditiona -> %0 in redirect pattern
         # must be the most inner block to the redirect rule

--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -26,8 +26,8 @@ telegram_alert_type=image
 send_matrix=false
 
 # General
-group_date_pattern="+%d-%m-%Y"
-file_date_pattern="+%d-%m-%Y_%H.%M.%S"
+group_date_pattern="+%Y-%m-%d"
+file_date_pattern="+%Y-%m-%d_%H-%M-%S"
 video_duration=10
 
 # Record from RTSP (RTSP H264 must be enabled)
@@ -39,13 +39,13 @@ video_rtsp_f=15
 
 # Snapshots
 save_snapshot=false
-save_snapshot_dir=/system/sdcard/DCIM/motion/stills
+save_snapshot_dir=/system/sdcard/DCIM/Motion/Stills
 save_snapshot_attr="0666"
 max_snapshot_days=20
 
 # Videos
 save_video=false
-save_video_dir=/system/sdcard/DCIM/motion/videos
+save_video_dir=/system/sdcard/DCIM/Motion/Videos
 save_video_attr="0666"
 max_video_days=10
 

--- a/firmware_mod/config/resolv.conf.dist
+++ b/firmware_mod/config/resolv.conf.dist
@@ -9,7 +9,8 @@
 ## List DNS server addresses, primary, secondary, etc
 #nameserver 192.168.1.1
 #nameserver 192.168.1.2
-#nameserver 192.168.1.3
+nameserver 1.1.1.1
+nameserver 8.8.8.8
 
 ## Domain of this system
 ## Determined automatically from fully-qualified hostname when unspecified

--- a/firmware_mod/config/resolv.conf.dist
+++ b/firmware_mod/config/resolv.conf.dist
@@ -9,8 +9,8 @@
 ## List DNS server addresses, primary, secondary, etc
 #nameserver 192.168.1.1
 #nameserver 192.168.1.2
-nameserver 1.1.1.1
-nameserver 8.8.8.8
+#nameserver 1.1.1.1
+#nameserver 8.8.8.8
 
 ## Domain of this system
 ## Determined automatically from fully-qualified hostname when unspecified

--- a/firmware_mod/config/rtspserver.conf.dist
+++ b/firmware_mod/config/rtspserver.conf.dist
@@ -12,6 +12,9 @@ LOGPATH="$LOGDIR/v4l2rtspserver-master.log"
 
 PORT=8554
 
+USERNAME=
+USERPASSWORD=
+
 # H264 RTSP server options
 # Examples:
 # RTSPH264OPTS="-W960 -H540"

--- a/firmware_mod/config/sendmail.conf.dist
+++ b/firmware_mod/config/sendmail.conf.dist
@@ -9,7 +9,7 @@ FROM="House.home@gmail.com"
 FROMNAME="`hostname`"
 
 # Login and pasword to access smtp server
-AUTH="john.doe"
+AUTH="john.doe@gmail.com"
 PASS="JOHNDOEPASSWORD"
 
 # Destination email

--- a/firmware_mod/controlscripts/recording
+++ b/firmware_mod/controlscripts/recording
@@ -2,7 +2,7 @@
 . /system/sdcard/config/rtspserver.conf
 
 PIDFILE="/run/recording.pid"
-DCIM_PATH="/system/sdcard/DCIM"
+DCIM_PATH="/system/sdcard/DCIM/Recording"
 
 ## UserName and password
 if [ "$USERNAME" != "" ]; then
@@ -27,11 +27,14 @@ start()
     echo "Recording already running.";
   else
     echo "Started recording."
-    SUB_DIR="$(date +%m%dFANG)"
+	# Add sub directory to main dcim path seperated by date then by
+	# hour for faster loading over ftp
+    SUB_DIR="$(date +%Y-%m-%d)/$(date +%H)"
     if [ ! -d "$DCIM_PATH/$SUB_DIR" ]; then
       mkdir -p "$DCIM_PATH/$SUB_DIR"
     fi
-    FILE_NAME="MOV_$(date +%H%M.h264)"
+	# Create the recording with timestamp
+    FILE_NAME="REC_$(date +%H-%M-%S.h264)"
     RECORDING_PATH="$DCIM_PATH/$SUB_DIR/$FILE_NAME"
     # wait for rtspserver to become available
     until pids=$(pidof v4l2rtspserver-master)

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -58,9 +58,9 @@ snapshot_tempfile=$(mktemp /tmp/snapshot-XXXXXXX)
 video_tempfile=$(mktemp /tmp/video-XXXXXXX)
 
 # Prepare filename, save datetime ASAP
-group_pattern="${group_date_pattern:-+%d-%m-%Y}"
+group_pattern="${group_date_pattern:-+%Y-%m-%d}"
 groupname=$(date "$group_pattern")
-filename_pattern="${file_date_pattern:-+%d-%m-%Y_%H.%M.%S}"
+filename_pattern="${file_date_pattern:-+%Y-%m-%d_%H-%M-%S}"
 filename=$(date "$filename_pattern")
 
 # First, take a snapshot (always)

--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -94,7 +94,6 @@ main() {
   [ -z "$chatId" ] && return 0 # no new messages
 
   cmd=$(echo "$json" | $JQ -r ".result[0].$messageAttr.text // \"\"")
-  
 
   if [ "$chatId" != "$userChatId" ]; then
     username=$(echo "$json" | $JQ -r ".result[0].$messageAttr.from.username // \"\"")

--- a/firmware_mod/scripts/timelapse.sh
+++ b/firmware_mod/scripts/timelapse.sh
@@ -5,7 +5,7 @@
 
 PIDFILE='/run/timelapse.pid'
 TIMELAPSE_CONF='/system/sdcard/config/timelapse.conf'
-BASE_SAVE_DIR='/system/sdcard/DCIM/timelapse'
+DCIM_PATH='/system/sdcard/DCIM/Timelapse'
 
 if [ -f "$TIMELAPSE_CONF" ]; then
     . "$TIMELAPSE_CONF" 2>/dev/null
@@ -21,14 +21,14 @@ last_prefix=''
 ts_started=$(date +%s)
 
 while true; do
-    SAVE_DIR=$BASE_SAVE_DIR
+    SAVE_DIR=$DCIM_PATH
     if [ $SAVE_DIR_PER_DAY -eq 1 ]; then
-        SAVE_DIR="$BASE_SAVE_DIR/$(date +%Y-%m-%d)"
+        SAVE_DIR="$DCIM_PATH/$(date +%Y-%m-%d)/$(date +%H)"
     fi
     if [ ! -d "$SAVE_DIR" ]; then
         mkdir -p $SAVE_DIR
     fi
-    filename_prefix="$(date +%Y-%m-%d_%H%M%S)"
+    filename_prefix="$(date +%Y-%m-%d_%H-%M-%S)"
     if [ "$filename_prefix" = "$last_prefix" ]; then
         counter=$(($counter + 1))
     else


### PR DESCRIPTION
Lighttpd.conf.dist: Added notes for disabling SSL
SSL left as on by default
Motion.conf.dist: Change pattern to make more sense when items are listed in explorer
Change paths case
resolv.cont.dist: Added public nameservers so that NTP will work by default if a static IP is set by user
rtspserver.conf.dist: Added missing settings that are created after UI page is saved anyway
sendmail.conf.dist: Clarify AUTH entry to match rest of example
recording: Add Recording to path to help seperate/categorise files
Add sub dir with date for faster dir loading
Change from MOV to REC to identify video as "recorting" type
detectionON.sh: Change group/file pattern to make list better/consistent
telegram-bot...: Remove blank line
timelapse.sh: Change path variable name to match rest of code
Add sub directories to help with loaading/filtering of files