### PR TITLE
Save correct SW auto night command line arguments

### DIFF
--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -478,7 +478,7 @@ if [ -n "$F_cmd" ]; then
     ;;
 
     save_sw_night_config)
-      night_mode_conf=$(echo "${F_val}"| sed "s/+/ /g" | sed "s/%2C/,/g")
+      night_mode_conf=$(echo "'${F_val}'"| sed "s/+/ /g" | sed "s/%2C/,/g")
       rewrite_config /system/sdcard/config/autonight.conf sw_parameters "$night_mode_conf"
       echo Saved $night_mode_conf
     ;;


### PR DESCRIPTION
autonight.conf.dist has arguments enclosed with ' but SW night configuration page passes arguments without. Currently, updating autonight.conf sw parameters using the SW night configuration page will stop autonight working correctly.