### PR TITLE
enable zram by default as per the original firmware

### DIFF
--- a/firmware_mod/config/swap.conf.dist
+++ b/firmware_mod/config/swap.conf.dist
@@ -2,6 +2,7 @@
 # in particular on the xiaofang & clones with only 64 mb 
 
 SWAP_ZRAM=true
+SWAP_ZRAM_SIZE=16777216
 
 # in case you want to use an additional swapfile, enable it here
 SWAP=false

--- a/firmware_mod/config/swap.conf.dist
+++ b/firmware_mod/config/swap.conf.dist
@@ -3,6 +3,7 @@
 
 SWAP_ZRAM=true
 
-SWAPFILE=false
-SWAPFILE_PATH="/system/sdcard/swapfile"
-SWAPFILE_SIZE=256
+# in case you want to use an additional swapfile, enable it here
+SWAP=false
+SWAPPATH="/system/sdcard/swapfile"
+SWAPSIZE=256

--- a/firmware_mod/config/swap.conf.dist
+++ b/firmware_mod/config/swap.conf.dist
@@ -1,6 +1,8 @@
 # If you need to run many services in parallel you may want to enable swap on your camera to avoid running out of memory
 # in particular on the xiaofang & clones with only 64 mb 
 
-SWAP=false
-SWAPPATH="/system/sdcard/swapfile"
-SWAPSIZE=256
+SWAP_ZRAM=true
+
+SWAPFILE=false
+SWAPFILE_PATH="/system/sdcard/swapfile"
+SWAPFILE_SIZE=256

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -68,7 +68,7 @@ if [ "$SWAP" = true ]; then
     echo "Swap file created in $SWAPPATH" >> $LOGPATH
   fi
   echo "Configuring swap file" >> $LOGPATH
-  swapon $SWAPPATH
+  swapon -p 10 $SWAPPATH
   echo "Swap set on file $SWAPPATH" >> $LOGPATH
 fi
 
@@ -77,7 +77,7 @@ if [ ! "$SWAP_ZRAM" = false ]; then
     echo 100 > /proc/sys/vm/swappiness
     echo 16777216 > /sys/block/zram0/disksize
     mkswap /dev/zram0
-    swapon /dev/zram0
+    swapon -p 20 /dev/zram0
 fi
 
 ## Create crontab dir and start crond:

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -60,15 +60,15 @@ if [ -f "$CONFIGPATH/swap.conf" ]; then
 fi
 
 ## Create a swap file on SD if desired
-if [ "$SWAPFILE" = true ]; then
-  if [ ! -f $SWAPFILE_PATH ]; then
-    echo "Creating ${SWAPFILE_SIZE}MB swap file on SD card"  >> $LOGPATH
-    dd if=/dev/zero of=$SWAPFILE_PATH bs=1M count=$SWAPFILE_SIZE
-    mkswap $SWAPFILE_PATH
-    echo "Swap file created in $SWAPFILE_PATH" >> $LOGPATH
+if [ "$SWAP" = true ]; then
+  if [ ! -f $SWAPPATH ]; then
+    echo "Creating ${SWAPSIZE}MB swap file on SD card"  >> $LOGPATH
+    dd if=/dev/zero of=$SWAPPATH bs=1M count=$SWAPSIZE
+    mkswap $SWAPPATH
+    echo "Swap file created in $SWAPPATH" >> $LOGPATH
   fi
   echo "Configuring swap file" >> $LOGPATH
-  swapon $SWAPFILE_PATH
+  swapon $SWAPPATH
   echo "Swap set on file $SWAPPATH" >> $LOGPATH
 fi
 

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -55,23 +55,29 @@ echo "Bind mounted /system/sdcard/root to /root" >> $LOGPATH
 mount -o bind /system/sdcard/etc /etc
 echo "Bind mounted /system/sdcard/etc to /etc" >> $LOGPATH
 
-## Create a swap file on SD if desired
-## please view the swap.conf.dist file for more infomation
 if [ -f "$CONFIGPATH/swap.conf" ]; then
   . $CONFIGPATH/swap.conf
-else
-  SWAP=false
 fi
-if [ "$SWAP" = true ]; then
-  if [ ! -f $SWAPPATH ]; then
-    echo "Creating ${SWAPSIZE}MB swap file on SD card"  >> $LOGPATH
-    dd if=/dev/zero of=$SWAPPATH bs=1M count=$SWAPSIZE
-    mkswap $SWAPPATH
-    echo "Swap file created in $SWAPPATH" >> $LOGPATH
+
+## Create a swap file on SD if desired
+if [ "$SWAPFILE" = true ]; then
+  if [ ! -f $SWAPFILE_PATH ]; then
+    echo "Creating ${SWAPFILE_SIZE}MB swap file on SD card"  >> $LOGPATH
+    dd if=/dev/zero of=$SWAPFILE_PATH bs=1M count=$SWAPFILE_SIZE
+    mkswap $SWAPFILE_PATH
+    echo "Swap file created in $SWAPFILE_PATH" >> $LOGPATH
   fi
   echo "Configuring swap file" >> $LOGPATH
-  swapon $SWAPPATH
+  swapon $SWAPFILE_PATH
   echo "Swap set on file $SWAPPATH" >> $LOGPATH
+fi
+
+# Create ZRAM swap as on the original firmware
+if [ ! "$SWAP_ZRAM" = false ]; then
+    echo 100 > /proc/sys/vm/swappiness
+    echo 16777216 > /sys/block/zram0/disksize
+    mkswap /dev/zram0
+    swapon /dev/zram0
 fi
 
 ## Create crontab dir and start crond:

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -75,7 +75,7 @@ fi
 # Create ZRAM swap as on the original firmware
 if [ ! "$SWAP_ZRAM" = false ]; then
     echo 100 > /proc/sys/vm/swappiness
-    echo 16777216 > /sys/block/zram0/disksize
+    echo $SWAP_ZRAM_SIZE > /sys/block/zram0/disksize
     mkswap /dev/zram0
     swapon -p 20 /dev/zram0
 fi


### PR DESCRIPTION
this prevents crashes due to memory exhaustion on xiaofeng and other
64mb models