### PR TITLE
PTZpresets.sh should not use inverted logic for motor control.

### DIFF
--- a/firmware_mod/scripts/PTZpresets.sh
+++ b/firmware_mod/scripts/PTZpresets.sh
@@ -7,7 +7,7 @@
 
 source /system/sdcard/scripts/common_functions.sh
 
-MOTOR=/system/sdcard/bin/motor
+MOTOR=/system/sdcard/bin/motor.bin
 pid=$$
 echo $pid > /run/PTZ_$pid.pid
 


### PR DESCRIPTION
PTZpresets.sh moves to an arbitrary location not up or down, left or right. Inverted logic on the motor script breaks this if you flip your video.