### PR TITLE
Allow example userscripts, with calibratePTZ example script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,8 @@ firmware_mod/config/rtspserver.conf
 firmware_mod/config/ntp_srv.conf
 firmware_mod/config/lighttpd.user
 firmware_mod/config/lighttpd.pem
-firmware_mod/config/userscripts/*/*
+firmware_mod/config/userscripts/motiondetection/*
+!firmware_mod/config/userscripts/motiondetection/*.dist
+firmware_mod/config/userscripts/startup/*
+!firmware_mod/config/userscripts/startup/*.dist
 firmware_mod/root/.ssh/*

--- a/firmware_mod/config/userscripts/startup/calibratePTZ.sh.dist
+++ b/firmware_mod/config/userscripts/startup/calibratePTZ.sh.dist
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Performs PTZ calibration at boot and if
+# /system/sdcard/config/cameraposition exists
+# will adjust camera to that position.
+# Disabled by default as calibration can cause issues
+# on cameras that do not have mechanical endstops.
+# To enable:
+# cp /system/sdcard/config/userscripts/startup/calibratePTZ.sh.dist /system/sdcard/config/userscripts/startup/calibratePTZ.sh
+
+/system/sdcard/bin/motor -d v
+
+FILECAMERAPOS=/system/sdcard/config/cameraposition
+
+if [ -f ${FILECAMERAPOS} ]; then
+    # Get values in saved config file
+    origin_x_axis=`grep "x:" ${FILECAMERAPOS} | sed "s/x: //"`
+    origin_y_axis=`grep "y:" ${FILECAMERAPOS} | sed "s/y: //"`
+else
+    # No such file exists: create it with the current values
+    /system/sdcard/bin/motor -d s > ${FILECAMERAPOS}
+fi
+
+# go to home for both axis
+/system/sdcard/scripts/PTZpresets.sh $origin_x_axis $origin_y_axis

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -260,7 +260,9 @@ done
 
 ## Autostart startup userscripts
 for i in /system/sdcard/config/userscripts/startup/*; do
-  $i &
+  if [ $i != *".dist" ]; then
+    $i &
+  fi
 done
 
 echo "Startup finished!" >> $LOGPATH

--- a/firmware_mod/scripts/PTZpresets.sh
+++ b/firmware_mod/scripts/PTZpresets.sh
@@ -7,7 +7,7 @@
 
 source /system/sdcard/scripts/common_functions.sh
 
-MOTOR=/system/sdcard/bin/motor
+MOTOR=/system/sdcard/bin/motor.bin
 pid=$$
 echo $pid > /run/PTZ_$pid.pid
 


### PR DESCRIPTION
Changes run.sh to only execute files in /system/sdcard/config/userscripts/startup/ if they do not end with .dist. This allows example scripts to be included in the repository and/or scripts to be deactivated.

This also includes an example script calibratPTZ.sh.dist that will perform a PTZ calibration at boot and if a /system/sdcard/config/cameraposition file exists it will also move the camera to the position it defines.

The script is disabled by default for two reasons:
1. Not all cameras are PTZ.
2. Cameras that do not have physical endstops can be damaged from repeated calibrations. There is a note about this in the example script.

To enable the calibratePTZ.sh.dist demo, or any other script, copy or rename it to NOT end in .dist.
Example:
cp /system/sdcard/config/userscripts/startup/calibratePTZ.sh.dist /system/sdcard/config/userscripts/startup/calibratePTZ.sh