### PR TITLE
Fix typo in status_overview.cgi

### DIFF
--- a/firmware_mod/www/cgi-bin/status_overview.cgi
+++ b/firmware_mod/www/cgi-bin/status_overview.cgi
@@ -56,7 +56,7 @@ cat << EOF
                 </tr>
                 <tr>
                   <td> Firmware commit </td>
-                  <td> $(if [ -s "/system/sdcard/VERSION" ]; then $(check_commit; else echo "Never updated. Make an update to get version."; fi) </td>
+                  <td> $(if [ -s "/system/sdcard/VERSION" ]; then $(check_commit); else echo "Never updated. Make an update to get version."; fi) </td>
                 </tr>
                 
                 <tr>


### PR DESCRIPTION
Latest commit leads to blank content on Overview page under the Information tab. Based on below, I think it is a typo.

/var/log/lighttpd-cgi-stderr.log
/system/sdcard/www/cgi-bin/status_overview.cgi: line 59: syntax error: unexpected "else" (expecting ")")