### PR TITLE
Reworking permissions of saved files and directories

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -29,6 +29,8 @@ send_matrix=false
 group_date_pattern="+%Y-%m-%d"
 file_date_pattern="+%Y-%m-%d_%H-%M-%S"
 video_duration=10
+save_files_attr="0644"
+save_dirs_attr="0755"
 
 # Record from RTSP (RTSP H264 must be enabled)
 # RTSP is alternative for `record_video` function in `detectionOn.sh` - instead of 1s-getimage gets real video.
@@ -40,13 +42,11 @@ video_rtsp_f=15
 # Snapshots
 save_snapshot=false
 save_snapshot_dir=/system/sdcard/DCIM/Motion/Stills
-save_snapshot_attr="0666"
 max_snapshot_days=20
 
 # Videos
 save_video=false
 save_video_dir=/system/sdcard/DCIM/Motion/Videos
-save_video_attr="0666"
 max_video_days=10
 
 # Configure FTP snapshots and videos

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -81,7 +81,7 @@ if [ "$save_snapshot" = true ] ; then
 
 	if [ ! -d "$save_snapshot_dir/$groupname" ]; then
 		mkdir -p "$save_snapshot_dir/$groupname"
-		chmod "$save_snapshot_attr" "$save_snapshot_dir/$groupname"
+		chmod "$save_dirs_attr" "$save_snapshot_dir/$groupname"
 	fi
 
 	# Limit the number of snapshots
@@ -89,7 +89,7 @@ if [ "$save_snapshot" = true ] ; then
 		rm -f "$save_snapshot_dir/$(ls -ltr "$save_snapshot_dir" | awk 'NR==2{print $9}')"
 	fi
 
-	chmod "$save_snapshot_attr" "$snapshot_tempfile"
+	chmod "$save_files_attr" "$snapshot_tempfile"
 	cp "$snapshot_tempfile" "$save_snapshot_dir/$groupname/$filename.jpg"
 	) &
 fi
@@ -101,7 +101,7 @@ if [ "$save_video" = true ] ; then
 
 	if [ ! -d "$save_video_dir/$groupname" ]; then
 		mkdir -p "$save_video_dir/$groupname"
-		chmod "$save_snapshot_attr" "$save_video_dir/$groupname"
+		chmod "$save_dirs_attr" "$save_video_dir/$groupname"
 	fi
 
 	# Limit the number of videos
@@ -109,7 +109,7 @@ if [ "$save_video" = true ] ; then
 		rm -r -f "$save_video_dir/$(ls -ltr "$save_video_dir" | awk 'NR==2{print $9}')"
 	fi
 
-	chmod "$save_video_attr" "$video_tempfile"
+	chmod "$save_files_attr" "$video_tempfile"
 	cp "$video_tempfile" "$save_video_dir/$groupname/$filename.mp4"
 	) &
 fi


### PR DESCRIPTION
"save_snapshots_attr" was used also for firectories containing videos, leading to non-obvious permission issues.

Permissions for snapshots and videos were grouped together into a new "save_files_attr" and a new "save_dirs_attr" has been introduced.

Closes #1413 