### PR TITLE
Change run.sh to include dmesg ref #1408

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -274,3 +274,6 @@ for i in /system/sdcard/config/userscripts/startup/*; do
 done
 
 echo "Startup finished!" >> $LOGPATH
+echo "" >> $LOGPATH
+echo "Contents of dmesg after startup:" >> $LOGPATH
+dmesg >> $LOGPATH


### PR DESCRIPTION
Some module startup e.g. RTL871X is not captured in startup.log. Record dmesg to startup.log to capture module problems e.g. Wifi issues,