### PR TITLE
Telegram Bot: support `channel_post`

### DIFF
--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -94,13 +94,15 @@ main() {
   messageAttr="message"
   messageVal=$(echo "$json" | $JQ -r '.result[0].message // ""')
   [ -z "$messageVal" ] && messageAttr="edited_message"
+  messageVal=$(echo "$json" | $JQ -r '.result[0].edited_message // ""')
+  [ -z "$messageVal" ] && messageAttr="channel_post"
   chatId=$(echo "$json" | $JQ -r ".result[0].$messageAttr.chat.id // \"\"")
   updateId=$(echo "$json" | $JQ -r '.result[0].update_id // ""')
-  if [ "$updateId" != "" ] && [ -z "$chatId" ]; then                                                                           
-  markAsRead $updateId                                                                                 
-  return 0                                                                                             
+  if [ "$updateId" != "" ] && [ -z "$chatId" ]; then
+  markAsRead $updateId
+  return 0
   fi;
-  
+
   [ -z "$chatId" ] && return 0 # no new messages
 
   cmd=$(echo "$json" | $JQ -r ".result[0].$messageAttr.text // \"\"")


### PR DESCRIPTION
posts to channels are of the type "channel_post" (not message): https://core.telegram.org/bots/api#getting-updates

This MR supports channel posts and should fix problems like #1368 and #1364

(perhaps there is a simpler solution, I am not that familiar with bash programming)