### PR TITLE
Fix telegram bot not replying (#1470)

### DIFF
--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -93,8 +93,7 @@ main() {
 
   messageAttr="message"
   messageVal=$(echo "$json" | $JQ -r '.result[0].message // ""')
-  [ -z "$messageVal" ] && messageAttr="edited_message"
-  messageVal=$(echo "$json" | $JQ -r '.result[0].edited_message // ""')
+  [ -z "$messageVal" ] && messageAttr="edited_message" && messageVal=$(echo "$json" | $JQ -r '.result[0].edited_message // ""')
   [ -z "$messageVal" ] && messageAttr="channel_post"
   chatId=$(echo "$json" | $JQ -r ".result[0].$messageAttr.chat.id // \"\"")
   updateId=$(echo "$json" | $JQ -r '.result[0].update_id // ""')


### PR DESCRIPTION
Fixxes https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/issues/1470.
Its an assignement issue:
on Line 96, the variable messageVal is checked if empty, and if yes, messageAttr is set to "edited_message".
Now on line 97, messageVal is always set to a json value, which may not be there. This line should actually be added to line 96 after it has been checked, it the messageVal is empty.
This fix ensures that messageVal is only set to the json value of '.result[0].edited_message' if messageVal was empty before.