### PR TITLE
hard crash on if [[ ${i: -3}... replaced with find

### DIFF
--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -267,11 +267,7 @@ for i in /system/sdcard/config/autostart/*; do
 done
 
 ## Autostart startup userscripts
-for i in /system/sdcard/config/userscripts/startup/*; do
-  if [[ ${i: -3} == ".sh" ]]; then
-    $i &
-  fi
-done
+/bin/find /system/sdcard/config/userscripts/startup/ -executable -name "*.sh" -exec {} \;
 
 echo "Startup finished!" >> $LOGPATH
 echo "" >> $LOGPATH


### PR DESCRIPTION
using find is a bit heavy handed but works.

crash might have to do with different busybox version running.
run.sh's bin/sh is BusyBox v1.22.1 (2017-06-29 11:15:20 CST)
after mount bind bin/busybox /bin/sh is BusyBox v1.32.0.git (2020-04-05 20:30:22 UTC)
that later version handles the if just fine

