### PR TITLE
Minor memory/cpu usage improvement for firmware_mod/www/cgi-bin/currentpic.cgi

### DIFF
--- a/firmware_mod/www/cgi-bin/currentpic.cgi
+++ b/firmware_mod/www/cgi-bin/currentpic.cgi
@@ -2,4 +2,4 @@
 
 echo "Content-type: image/jpeg"
 echo ""
-/system/sdcard/bin/getimage
+exec /system/sdcard/bin/getimage


### PR DESCRIPTION
This saves 1 process in memory and extra input/output handling of the shell running for the cgi

Instead of forking a new process for getimage the current processes just execve the new binary