### PR TITLE
Fixes the disk_space information gathering command

### DIFF
--- a/firmware_mod/www/cgi-bin/api.cgi
+++ b/firmware_mod/www/cgi-bin/api.cgi
@@ -136,9 +136,9 @@ if [ -n "$F_action" ]; then
       }
     },
     \"disk_space\": {
-      \"total\": $(df | tr -s ' ' $'\t' | grep /dev/mmcblk0p1 | cut -f2),
-      \"used\": $(df | tr -s ' ' $'\t' | grep /dev/mmcblk0p1 | cut -f3),
-      \"free\": $(df | tr -s ' ' $'\t' | grep /dev/mmcblk0p1 | cut -f4)
+      \"total\": $(df | tr -s ' ' $'\t' | grep /dev/mmcblk0p1 | grep /system/sdcard | cut -f2),
+      \"used\": $(df | tr -s ' ' $'\t' | grep /dev/mmcblk0p1 | grep /system/sdcard | cut -f3),
+      \"free\": $(df | tr -s ' ' $'\t' | grep /dev/mmcblk0p1 | grep /system/sdcard | cut -f4)
     },
     \"memory\": {
       \"total\": $(cat /proc/meminfo  | tr -s ' ' $'\t' | grep MemTotal: | cut -f2),


### PR DESCRIPTION
The current command which gathers the disk space informations returns multiple (totally equal) values: 

![image](https://user-images.githubusercontent.com/8693771/90927630-b7e5ba00-e3f5-11ea-8f37-c3333f3da3dd.png)

As you can see in the following image (The command executed without the `| cut -f2` at the end) the filesystem entry occurs multiple times with different `mounted on` data:

![image](https://user-images.githubusercontent.com/8693771/90927704-dcda2d00-e3f5-11ea-8878-7073c8cb0a55.png)

Because of this I've added an additional `| grep /system/sdcard` to the command to get only one line without the other equal informations:

![image](https://user-images.githubusercontent.com/8693771/90927977-4fe3a380-e3f6-11ea-9a7e-691c6ba99ac6.png)

Without this change the JSON output contains the same number multiple times without any formatting which leads in an unparseable JSON output.