### PR TITLE
Set expiration date of 2038 for cookies

### DIFF
--- a/firmware_mod/www/scripts/index.html.js
+++ b/firmware_mod/www/scripts/index.html.js
@@ -172,7 +172,7 @@ $(document).ready(function () {
 
 // set theme cookie
 function setCookie(name, value) {
-    document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + "; path=/";
+    document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + "; path=/; expires=Tue, 19 Jan 2038 03:14:07 GMT";
 }
 // get theme cookie
 function getCookie(name) {


### PR DESCRIPTION
(Note that some browsers may limit this; e.g., Safari sets it to 7 days. It's still better than a session cookie)

Closes #1561 