### PR TITLE
Exposes the motor speed attribute in the api endpoint

### DIFF
--- a/firmware_mod/www/cgi-bin/api.cgi
+++ b/firmware_mod/www/cgi-bin/api.cgi
@@ -153,7 +153,8 @@ if [ -n "$F_action" ]; then
     },
     \"motor\": {
       \"x\": $($MOTOR -d s | sed -n '1 p' | awk '{print $2}'),
-      \"y\": $($MOTOR -d s | sed -n '2 p' | awk '{print $2}')
+      \"y\": $($MOTOR -d s | sed -n '2 p' | awk '{print $2}'),
+      \"speed\": $($MOTOR -d s | sed -n '3 p' | awk '{print $2}')
     }
   }
 }"


### PR DESCRIPTION
This change adds the `speed` attribute of the `motor.bin` file to the API endpoint. I forgot this change within my last pr which added the x and y value for the motor.