### PR TITLE
Add video file to the motion detection user scripts

### DIFF
--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -265,7 +265,7 @@ fi
 for i in /system/sdcard/config/userscripts/motiondetection/*; do
     if [ -x "$i" ]; then
         debug_msg "Running: $i on $snapshot_tempfile"
-        $i on "$snapshot_tempfile" &
+        $i on "$snapshot_tempfile" "$video_tempfile" &
     fi
 done
 


### PR DESCRIPTION
Since it's in user script space, having access to the tempfile to do our own archiving or actions would be ideal.