### PR TITLE
Fixed the timezone: Europe/Amsterdam

### DIFF
--- a/firmware_mod/www/json/timezone.json
+++ b/firmware_mod/www/json/timezone.json
@@ -293,7 +293,7 @@
 "Australia/Melbourne":"EST-10EST,M10.1.0,M4.1.0/3",
 "Australia/Perth":"WST-8",
 "Australia/Sydney":"EST-10EST,M10.1.0,M4.1.0/3",
-"Europe/Amsterdam":"CET-1CEST,M3.5.0,M10.5.0/3",
+"Europe/Amsterdam":"CET-1CEST-2,M3.5.0,M10.5.0/3",
 "Europe/Andorra":"CET-1CEST,M3.5.0,M10.5.0/3",
 "Europe/Athens":"EET-2EEST,M3.5.0/3,M10.5.0/4",
 "Europe/Belgrade":"CET-1CEST,M3.5.0,M10.5.0/3",

--- a/firmware_mod/www/json/timezones.tsv
+++ b/firmware_mod/www/json/timezones.tsv
@@ -295,7 +295,7 @@ Australia/Lord_Howe	LHST-10:30LHST-11,M10.1.0,M4.1.0
 Australia/Melbourne	EST-10EST,M10.1.0,M4.1.0/3
 Australia/Perth	WST-8
 Australia/Sydney	EST-10EST,M10.1.0,M4.1.0/3
-Europe/Amsterdam	CET-1CEST,M3.5.0,M10.5.0/3
+Europe/Amsterdam	CET-1CEST-2,M3.5.0,M10.5.0/3
 Europe/Andorra	CET-1CEST,M3.5.0,M10.5.0/3
 Europe/Athens	EET-2EEST,M3.5.0/3,M10.5.0/4
 Europe/Belgrade	CET-1CEST,M3.5.0,M10.5.0/3


### PR DESCRIPTION
Fixed time zone for Europe/Amsterdam so it will correctly set the time (before it was one hour behind).

(issue #1619 )