### PR TITLE
Fix 'rtsp-h264' still set as an autostart entry when 'rtsp' is now the service to use

### DIFF
--- a/firmware_mod/config/autostart/rtsp
+++ b/firmware_mod/config/autostart/rtsp
@@ -1,0 +1,2 @@
+#!/bin/sh
+/system/sdcard/controlscripts/rtsp

--- a/firmware_mod/config/autostart/rtsp-h264
+++ b/firmware_mod/config/autostart/rtsp-h264
@@ -1,2 +1,0 @@
-#!/bin/sh
-/system/sdcard/controlscripts/rtsp-h264


### PR DESCRIPTION
In 1e2f96612f4ad7852697609669d72532aea2a314 the services 'rtsp-h264' and 'rtsp-mjpeg' were combined into a single 'rtsp' service, however an entry for 'rtsp-h264' still remained in the autostart folder. This is a problem for the user because this entry does not appear in the Web UI which means it cannot be easily removed, and also appears as if an RTSP server is not running when it is.