### PR TITLE
Added button to the live page that downloads a JPEG screenshot

### DIFF
--- a/firmware_mod/www/cgi-bin/downloadpic.cgi
+++ b/firmware_mod/www/cgi-bin/downloadpic.cgi
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+FILE_NAME="$(date +%Y-%m-%d-%H-%M-%S)"
+
+echo "Content-type: image/jpeg"
+echo "Content-Disposition: attachment; filename=\"$FILE_NAME.jpeg\""
+echo ""
+exec /system/sdcard/bin/getimage

--- a/firmware_mod/www/cgi-bin/ui_camera.cgi
+++ b/firmware_mod/www/cgi-bin/ui_camera.cgi
@@ -109,7 +109,7 @@ if [ -n "$F_cmd" ]; then
 	if [ -n  "${F_videoPort+x}" ]; then
 		videoport=$(echo "${F_videoPort}"| tr '\n')
 		rewrite_config /system/sdcard/config/rtspserver.conf PORT "$videoport"
-		echo "Set video port tp ${videoport}"
+		echo "Set video port tp ${videoport}<br />"
 	fi
 	if [ -n "${F_autoNightMode+x}" ]; then
 		rewrite_config /system/sdcard/config/autonight.conf autonight_mode $F_autoNightMode

--- a/firmware_mod/www/js/control.js
+++ b/firmware_mod/www/js/control.js
@@ -57,7 +57,7 @@ function showupdatepage(result) {
         var update_status = parseInt(update[1],10);
 
         if (update_status == 0) {
-            $('#updatemsg').html("You have already the lastest version from the " + update[0] + " branch")
+            $('#updatemsg').html("You have already the latest version from the " + update[0] + " branch")
             if (update[0] == "master") {
                 $('#updatemsg').append('<button class="accordion" type="button" onclick="accordionUpdate(this);">Other Update Options</button> \
                 <div class="panel"> <p></p>\

--- a/firmware_mod/www/js/live.js
+++ b/firmware_mod/www/js/live.js
@@ -13,6 +13,11 @@ function refreshLiveImage() {
     $("#liveview").attr("src", "/cgi-bin/currentpic.cgi?" + ts);
 }
 
+//Function to download a screenshot
+function downloadScreenshot() {
+    var ts = new Date().getTime();
+    window.location.href = "/cgi-bin/downloadpic.cgi?" + ts;
+}
 
 //Function to refresh side bar buttons
 function refreshSideBar() {

--- a/firmware_mod/www/live.html
+++ b/firmware_mod/www/live.html
@@ -24,6 +24,7 @@
       </div>
         <div id="cam-control" class="w3-display-bottomright w3-container w3-hide">
           <button id="btn-record" class="w3-button w3-circle w3-black" onclick="record('on')" title="Record On/Off"><span><i class="fas fa-video"></i></span></button>
+          <button id="btn-screenshot" class="w3-button w3-circle w3-black" onclick="downloadScreenshot()" title="Download Screenshot"><span><i class="fas fa-image"></i></span></button>
           <button id="btn-ptz" class="w3-button w3-circle w3-black" onclick="PTZControl('show')" title="PTZ Control"> <i class="fa fa-arrows-alt"></i></button>
           <button id="btn-settings" class="w3-button w3-circle w3-black" onclick="w3_open()" title="Camera settings"> <i class="fa fa-cog"></i></button>
           <p></p>


### PR DESCRIPTION
This PR adds an extra button alongside the Record button on the live view (see below) that immediately downloads a screenshot as a JPEG file.

![image](https://user-images.githubusercontent.com/465698/101483934-c5956000-3950-11eb-8cac-db62ff223cf8.png)

I also fixed a spelling mistake and a missing line break (when saving new video config) that I found.