### PR TITLE
Save snapshots/videos on motion vales are not saved.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ firmware_mod/config/userscripts/motiondetection/*
 firmware_mod/config/userscripts/startup/*
 !firmware_mod/config/userscripts/startup/*.dist
 firmware_mod/root/.ssh/*
+/.vs/Xiaomi-Dafang-Hacks/v16/.suo
+/.vs/VSWorkspaceState.json
+/.vs/slnx.sqlite
+/.vs/ProjectSettings.json
+/.vs/Xiaomi-Dafang-Hacks/config/applicationhost.config

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,3 @@ firmware_mod/config/userscripts/motiondetection/*
 firmware_mod/config/userscripts/startup/*
 !firmware_mod/config/userscripts/startup/*.dist
 firmware_mod/root/.ssh/*
-/.vs/Xiaomi-Dafang-Hacks/v16/.suo
-/.vs/VSWorkspaceState.json
-/.vs/slnx.sqlite
-/.vs/ProjectSettings.json
-/.vs/Xiaomi-Dafang-Hacks/config/applicationhost.config

--- a/firmware_mod/www/cgi-bin/ui_motion.cgi
+++ b/firmware_mod/www/cgi-bin/ui_motion.cgi
@@ -25,6 +25,7 @@ if [ -n "$F_cmd" ]; then
     echo "motionTimeout#:#${motion_timeout}"
     echo "motionTracking#:#${motion_tracking}"
     echo "saveSnapshot#:#${save_snapshot}"
+    echo "saveVideo#:#${save_video}"
     echo "maxSnaphotDays#:#${max_snapshot_days}"
     echo "maxVideoDays#:#${max_video_days}"
     echo "ftpSnapshot#:#${ftp_snapshot}"
@@ -85,10 +86,10 @@ if [ -n "$F_cmd" ]; then
 	    rewrite_config /system/sdcard/config/motion.conf motion_timeout $F_motionTimeout
 		  echo "Motion timeout set to $F_motionTimeout<br/>"
 	  fi
-    if [ -n "${F_saveSnaphot+x}" ]; then
-		F_saveSnaphot=$(printf '%b' "${F_saveSnaphot//%/\\x}")
-	    rewrite_config /system/sdcard/config/motion.conf save_snapshot $F_saveSnaphot
-		  echo "Save snapshot set to $F_saveSnaphot<br/>"
+    if [ -n "${F_saveSnapshot+x}" ]; then
+		F_saveSnapshot=$(printf '%b' "${F_saveSnapshot//%/\\x}")
+	    rewrite_config /system/sdcard/config/motion.conf save_snapshot $F_saveSnapshot
+		  echo "Save snapshot set to $F_saveSnapshot<br/>"
 	  fi
     if [ -n "${F_maxSnaphotDays+x}" ]; then
 		F_maxSnaphotDays=$(printf '%b' "${F_maxSnaphotDays//%/\\x}")

--- a/firmware_mod/www/motion.html
+++ b/firmware_mod/www/motion.html
@@ -74,7 +74,7 @@
     <div class="w3-row-padding">
         <div class="w3-half">
             <label>Save snapshots on motion</label>
-            <select id="saveSnaphot" class="w3-select">
+            <select id="saveSnapshot" class="w3-select">
                 <option value="false">Deactivate</option>
                 <option value="true">Activate</option>
             </select>


### PR DESCRIPTION
**Description:**
Save snapshots/videos on motion vales are not saved.

**To Reproduce:**
1. SET **Motion Settings** > **Storage** > **Local Storage** > "Save snapshots on motion" to **Activate**
2. Reload the configuration.
3. Changes are not reflected or remains to be **Deactivate**

**Changes:**
_ui_motion.cgi_
1. Changed the variable `saveSnaphot` to `saveSnapshot`
2. Added `    echo "saveVideo#:#${save_video}"` for command `get_config`.
2. Added the the code below for the `save_config` command.
```
    if [ -n "${F_saveVideo+x}" ]; then
  F_saveVideo=$(printf '%b' "${F_saveVideo//%/\\x}")
     rewrite_config /system/sdcard/config/motion.conf save_video $F_saveVideo
    echo "Save video set to $F_saveVideo<br/>"
   fi
```

_motion.html_
1. Renamed `saveSnaphot` to `saveSnapshot` to reflect the changes done in ui_motion.cgi.

Note:
Please discard the changes in `.gitignore`.