### PR TITLE
Ignore motion events when night mode is switched on/off

### DIFF
--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -24,7 +24,7 @@ send_email=false
 send_telegram=false
 telegram_alert_type=image
 send_matrix=false
-night_delay=30
+night_mode_event_delay=30
 
 # General
 group_date_pattern="+%Y-%m-%d/%H"

--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -24,6 +24,7 @@ send_email=false
 send_telegram=false
 telegram_alert_type=image
 send_matrix=false
+night_delay=30
 
 # General
 group_date_pattern="+%Y-%m-%d/%H"

--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -703,6 +703,7 @@ motion_mqtt_video(){
 night_mode(){
   case "$1" in
   on)
+	touch /tmp/last-night
 	/system/sdcard/bin/setconf -k n -v 1
 	. /system/sdcard/config/autonight.conf
 	if [ -z "$ir_led_off" ] || [ $ir_led_off = false ]; then
@@ -713,6 +714,7 @@ night_mode(){
 	ir_cut off
 	;;
   off)
+	touch /tmp/last-night
 	ir_led off
 	ir_cut on
 	/system/sdcard/bin/setconf -k n -v 0

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -47,6 +47,15 @@ record_video () {
 	fi
 }
 
+if [ -f /tmp/last-night -a -n "$night_delay" -a "$night_delay" -gt 0 ]; then
+	now_ts="$(date +%s)"
+	night_ts="$(/system/sdcard/bin/busybox stat -c %Y /tmp/last-night)"
+	dt="$(($now_ts-$night_ts))"
+	if [ "$dt" -lt "$night_delay" ]; then
+		exit 0
+	fi
+fi
+
 # Turn on the amber led
 if [ "$motion_trigger_led" = true ] ; then
 	debug_msg "Trigger LED"

--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -47,11 +47,11 @@ record_video () {
 	fi
 }
 
-if [ -f /tmp/last-night -a -n "$night_delay" -a "$night_delay" -gt 0 ]; then
+if [ -f /tmp/last-night -a -n "$night_mode_event_delay" -a "$night_mode_event_delay" -gt 0 ]; then
 	now_ts="$(date +%s)"
 	night_ts="$(/system/sdcard/bin/busybox stat -c %Y /tmp/last-night)"
 	dt="$(($now_ts-$night_ts))"
-	if [ "$dt" -lt "$night_delay" ]; then
+	if [ "$dt" -lt "$night_mode_event_delay" ]; then
 		exit 0
 	fi
 fi

--- a/firmware_mod/www/cgi-bin/ui_motion.cgi
+++ b/firmware_mod/www/cgi-bin/ui_motion.cgi
@@ -51,7 +51,8 @@ if [ -n "$F_cmd" ]; then
     echo "sendTelegram#:#${send_telegram}"
     echo "telegramAlertType#:#${telegram_alert_type}"
     echo "sendMatrix#:#${send_matrix}"
-    
+    echo "nightDelay#:#${night_delay}"
+
 	;;
   save_config)
     if [ -n "${F_motionDetection+x}" ]; then
@@ -74,7 +75,7 @@ if [ -n "$F_cmd" ]; then
         echo -n "Motion color indicator set to "
         echo -n $(echo $color | cut -d ' ' -f $(($F_motionIndicatorColor + 1)))
 		    echo "<br />"
-      fi 
+      fi
 	  fi
     if [ -n "${F_motionTracking+x}" ]; then
 		F_motionTracking=$(printf '%b' "${F_motionTracking//%/\\x}")
@@ -221,6 +222,11 @@ if [ -n "$F_cmd" ]; then
 	    rewrite_config /system/sdcard/config/motion.conf send_matrix $F_sendMatrix
 		  echo "Send Matrix on motion set to $F_sendMatrix<br/>"
 	  fi
+    if [ -n "${F_nightDelay+x}" ]; then
+  		F_nightDelay=$(printf '%b' "${F_nightDelay//%/\\x}")
+	    rewrite_config /system/sdcard/config/motion.conf night_delay $F_nightDelay
+		  echo "Motion night mode delay set to $F_nightDelay<br/>"
+	  fi
     if [ -n "${F_regions+x}" ]; then
 	  F_regions=$(printf '%b' "${F_regions//%/\\x}")
 	    rewrite_config /system/sdcard/config/motion.conf region_of_interest $F_regions
@@ -240,4 +246,3 @@ if [ -n "$F_cmd" ]; then
   fi
 
 exit 0
-

--- a/firmware_mod/www/cgi-bin/ui_motion.cgi
+++ b/firmware_mod/www/cgi-bin/ui_motion.cgi
@@ -51,7 +51,7 @@ if [ -n "$F_cmd" ]; then
     echo "sendTelegram#:#${send_telegram}"
     echo "telegramAlertType#:#${telegram_alert_type}"
     echo "sendMatrix#:#${send_matrix}"
-    echo "nightDelay#:#${night_delay}"
+    echo "nightModeEventDelay#:#${night_mode_event_delay}"
 
 	;;
   save_config)
@@ -222,10 +222,10 @@ if [ -n "$F_cmd" ]; then
 	    rewrite_config /system/sdcard/config/motion.conf send_matrix $F_sendMatrix
 		  echo "Send Matrix on motion set to $F_sendMatrix<br/>"
 	  fi
-    if [ -n "${F_nightDelay+x}" ]; then
-  		F_nightDelay=$(printf '%b' "${F_nightDelay//%/\\x}")
-	    rewrite_config /system/sdcard/config/motion.conf night_delay $F_nightDelay
-		  echo "Motion night mode delay set to $F_nightDelay<br/>"
+    if [ -n "${F_nightModeEventDelay+x}" ]; then
+  		F_nightModeEventDelay=$(printf '%b' "${F_nightModeEventDelay//%/\\x}")
+	    rewrite_config /system/sdcard/config/motion.conf night_mode_event_delay $F_nightModeEventDelay
+		  echo "Motion night mode delay set to $F_nightModeEventDelay<br/>"
 	  fi
     if [ -n "${F_regions+x}" ]; then
 	  F_regions=$(printf '%b' "${F_regions//%/\\x}")

--- a/firmware_mod/www/motion.html
+++ b/firmware_mod/www/motion.html
@@ -275,7 +275,7 @@
     </div>
     <div class="w3-container">
         <label>Night mode delay (ignore motion events after switching night mode)</label>
-        <input class="w3-input" id="nightDelay" type="number" size="6">
+        <input class="w3-input" id="nightModeEventDelay" type="number" size="6">
     </div>
     <p><button class="w3-btn w3-theme" >Save</button></form></p>
 </div>

--- a/firmware_mod/www/motion.html
+++ b/firmware_mod/www/motion.html
@@ -273,6 +273,10 @@
             <option value="true">Activate</option>
         </select>
     </div>
+    <div class="w3-container">
+        <label>Night mode delay (ignore motion events after switching night mode)</label>
+        <input class="w3-input" id="nightDelay" type="number" size="6">
+    </div>
     <p><button class="w3-btn w3-theme" >Save</button></form></p>
 </div>
 <!-- Zones Tab -->


### PR DESCRIPTION
This adds a configurable 30s period in which motion events are ignored when night mode is toggled. This prevents my cameras from sending a bunch of notifications at dusk and dawn while the night mode is settling.