### PR TITLE
Mdns responder

### DIFF
--- a/firmware_mod/config/autostart/mdns-responder
+++ b/firmware_mod/config/autostart/mdns-responder
@@ -1,0 +1,2 @@
+#!/bin/sh
+/system/sdcard/controlscripts/mdns-responder

--- a/firmware_mod/controlscripts/mdns-responder
+++ b/firmware_mod/controlscripts/mdns-responder
@@ -1,5 +1,5 @@
 #!/bin/sh
-PIDFILE="/var/run/mDNSResponder.pid"
+PIDFILE="/run/mdns-responder.pid"
 
 status()
 {
@@ -15,7 +15,7 @@ start()
   	echo "mDNSResponder already running";
   else
     echo "Starting mDNSResponder";
-		/system/sdcard/bin/mDNSResponder -b -n "$(hostname)" -t _rtsp._tcp -p 8554
+		/system/sdcard/bin/mDNSResponder -b -P "$PIDFILE" -n "$(hostname)" -t _rtsp._tcp -p 8554
   fi
 }
 

--- a/firmware_mod/controlscripts/mdns-responder
+++ b/firmware_mod/controlscripts/mdns-responder
@@ -1,0 +1,37 @@
+#!/bin/sh
+PIDFILE="/var/run/mDNSResponder.pid"
+
+status()
+{
+  pid="$(cat "$PIDFILE" 2>/dev/null)"
+  if [ "$pid" ]; then
+  	kill -0 "$pid" >/dev/null && echo "PID: $pid" || return 1
+  fi
+}
+
+start()
+{
+  if [ -f "$PIDFILE" ]; then
+  	echo "mDNSResponder already running";
+  else
+    echo "Starting mDNSResponder";
+		/system/sdcard/bin/mDNSResponder -b -n "$(hostname)" -t _rtsp._tcp -p 8554
+  fi
+}
+
+stop()
+{
+  pid="$(cat "$PIDFILE" 2>/dev/null)"
+  if [ "$pid" ]; then
+	  kill "$pid" && rm "$PIDFILE"
+  fi
+}
+
+if [ $# -eq 0 ]; then
+  start
+else
+  case $1 in start|stop|status)
+	$1
+	;;
+  esac
+fi

--- a/firmware_mod/www/cgi-bin/ui_control.cgi
+++ b/firmware_mod/www/cgi-bin/ui_control.cgi
@@ -13,8 +13,8 @@ echo ""
 if [ -n "$F_cmd" ]; then
   case "$F_cmd" in
   get_services)
-    services="auto-night-detection debug-on-osd ftp_server mqtt-control mqtt-status onvif-srvd recording rtsp sound-on-startup telegram-bot timelapse"
-    for service in $services ; do  
+    services="auto-night-detection debug-on-osd ftp_server mdns-responder mqtt-control mqtt-status onvif-srvd recording rtsp sound-on-startup telegram-bot timelapse"
+    for service in $services ; do
       echo "${service}#:#$(test -f /run/${service}.pid && echo 'started' || echo 'stopped')#:#$(test -f /system/sdcard/config/autostart/${service} && echo 'true' || echo 'false')#:#false"
     done
 	return


### PR DESCRIPTION
Adds (and autoruns by default) mDNSResponder and advertises the rtsp stream. This allows other hosts to discover both the hostname and the rtsp stream address via mDNS. (Now you can ping your camera at dafang.local)