### PR TITLE
the bot should only answer to commands that starts with "/"

### DIFF
--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -66,7 +66,7 @@ respond() {
 	/imagealerts) imageAlerts;;
 	/videoalerts) videoAlerts;;
 	/help | /start) $TELEGRAM m "######### Bot commands #########\n# /mem - show memory information\n# /shot - take a snapshot\n# /on - motion detection on\n# /off - motion detection off\n# /nighton - night mode on\n# /nightoff - night mode off\n# /textalerts - Text alerts on motion detection\n# /imagealerts - Image alerts on motion detection\n# /videoalerts - Video alerts on motion detection";;
-	*) $TELEGRAM m "I can't respond to '$cmd' command"
+	/*) $TELEGRAM m "I can't respond to '$cmd' command"
   esac
 }
 


### PR DESCRIPTION
If a bot is in a group (where a lot of other messages are sent) it can be very noisy if the bot always answers that he can not understand the command.