### PR TITLE
Add LD_LIBRARY_PATH to .profile

### DIFF
--- a/firmware_mod/root/.profile
+++ b/firmware_mod/root/.profile
@@ -7,5 +7,5 @@ PATH=/system/sdcard/bin:$PATH
 # load some convenience functions 
 . /system/sdcard/scripts/common_functions.sh
 
-# Add our custom libararies to path
+# Add our custom libraries to path
 LD_LIBRARY_PATH=/system/sdcard/lib:$LD_LIBRARY_PATH

--- a/firmware_mod/root/.profile
+++ b/firmware_mod/root/.profile
@@ -6,3 +6,6 @@ PATH=/system/sdcard/bin:$PATH
 
 # load some convenience functions 
 . /system/sdcard/scripts/common_functions.sh
+
+# Add our custom libararies to path
+LD_LIBRARY_PATH=/system/sdcard/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
I often get error messages when accessing via SSH due to missing paths in PATH and LD_LIBRARY_PATH variables.  Add a .profile to /root to update paths


Before:
```
[root@KitchenCam:~]# env
USER=root
SSH_CLIENT=<REDACTED>
SHLVL=1
LD_LIBRARY_PATH=/thirdlib:/system/lib
HOME=/root
SSH_TTY=/dev/pts/0
PS1=[\u@\h:\W]#
LOGNAME=root
TERM=xterm-256-color
PATH=/system/bin:/bin:/sbin:/usr/bin:/usr/sbin
SHELL=/bin/sh
PWD=/root
SSH_CONNECTION=<REDACTED>
```

After:
```
[root@KitchenCam:~]# env
USER=root
SSH_CLIENT=<REDACTED>
SHLVL=1
LD_LIBRARY_PATH=/system/sdcard/lib:/thirdlib:/system/lib
HOME=/root
SSH_TTY=/dev/pts/0
PS1=[\u@\h:\W]#
LOGNAME=root
TERM=xterm-256-color
PATH=/system/bin:/bin:/sbin:/usr/bin:/usr/sbin:/system/sdcard/bin
SHELL=/bin/sh
PWD=/root
SSH_CONNECTION=<REDACTED>
```