### PR TITLE
Fix: waiting for all background jobs to finish before send snapshot

### DIFF
--- a/firmware_mod/scripts/detectionOn.sh
+++ b/firmware_mod/scripts/detectionOn.sh
@@ -131,6 +131,12 @@ send_snapshot() {
 		$smbclient_cmd -D "$smb_stills_path" -c "lcd /tmp; mkdir $groupname; cd $groupname; put $snapshot_tempfilename; rename $snapshot_tempfilename $filename.jpg"
 		) &
 	fi
+	# Wait for all background jobs to finish before existing
+	debug_msg "Waiting for background jobs to end in send_snapshot function:"
+	for jobpid in $(jobs -p); do
+		wait "$jobpid"
+		debug_msg "Job in send_snapshot function $jobpid ended"
+	done
 
 }
 


### PR DESCRIPTION
Fixed deletion of a temporary file before the snapshot is complete