### PR TITLE
Fix update w3.css

### DIFF
--- a/firmware_mod/www/lib/w3css/w3.css
+++ b/firmware_mod/www/lib/w3css/w3.css
@@ -24,7 +24,7 @@ legend{color:inherit;display:table;max-width:100%;padding:0;white-space:normal}t
 [type=search]::-webkit-search-decoration{-webkit-appearance:none}
 ::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}
 /* End extract */
-html,body{font-family:Verdana,sans-serif;font-size:15px;line-height:1.5,height:100%}html{overflow-x:hidden}
+html,body{font-family:Verdana,sans-serif;font-size:15px;line-height:1.5;height:100%}html{overflow-x:hidden}
 h1{font-size:36px}h2{font-size:30px}h3{font-size:24px}h4{font-size:20px}h5{font-size:18px}h6{font-size:16px}.w3-serif{font-family:serif}
 h1,h2,h3,h4,h5,h6{font-family:"Segoe UI",Arial,sans-serif;font-weight:400;margin:10px 0}.w3-wide{letter-spacing:4px}
 hr{border:0;border-top:1px solid #eee;margin:20px 0}


### PR DESCRIPTION
The previous PR I submitted was supposed to make the footer object stick to the bottom of the page but it did not work. This was because I missed a comma when adding the relevant changes.

This PR changes one comma in w3.css to a semi-colon, fixing the desired footer behaviour.