### PR TITLE
Fix missing directory structure on letsencrypt

### DIFF
--- a/firmware_mod/config/ssl/letsencrypt_setup.sh
+++ b/firmware_mod/config/ssl/letsencrypt_setup.sh
@@ -53,6 +53,7 @@ fi
 
 
 ## Adding cronjob to keep the cert updated
+mkdir -p ${CONFIGPATH}/cron/periodic/weekly/letsencrypt
 cat > ${CONFIGPATH}/cron/periodic/weekly/letsencrypt <<EOF
 #!/bin/sh
 PATH=/system/sdcard/bin:/system/bin:/bin:/sbin:/usr/bin:/usr/sbin


### PR DESCRIPTION
When creating the cron script, the directories may/may not already exist.  In my case, they did not, so the script fails.

This makes sure the directory exists first to avoid the error.