### PR TITLE
Implement Recording Rollover

### DIFF
--- a/firmware_mod/config/cron/crontabs/root
+++ b/firmware_mod/config/cron/crontabs/root
@@ -4,3 +4,4 @@
 0       2       *       *       *       busybox run-parts /system/sdcard/config/cron/periodic/daily
 0       3       *       *       6       busybox run-parts /system/sdcard/config/cron/periodic/weekly
 0       5       1       *       *       busybox run-parts /system/sdcard/config/cron/periodic/monthly
+*/30 	  *	      *       *	      *       /system/sdcard/scripts/roll-recording roll

--- a/firmware_mod/config/recording.conf.dist
+++ b/firmware_mod/config/recording.conf.dist
@@ -1,0 +1,13 @@
+#######################################################################
+# Edit this file and move it to /system/sdcard/config/recording.conf  #
+# if you need to add options, otherwise defaults will be used	      #
+#######################################################################
+
+# Configure Recording
+
+# Roll recording means that the recording file will be split, not just one big file
+# the recording will be split every 30 minutes, for now it is not configurable
+ROLL_RECORDING_ENABLE=false
+
+# The recording will be deleted after some period of time, default is 24H
+ROLL_RECORDING_RETENTION_MINUTES=1440

--- a/firmware_mod/scripts/roll-recording
+++ b/firmware_mod/scripts/roll-recording
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+roll()
+{
+	if [ ! -f /system/sdcard/config/recording.conf ]; then
+		cp /system/sdcard/config/recording.conf.dist /system/sdcard/config/recording.conf
+	fi
+
+	if [ ! -f /run/recording.pid ]; then
+		exit
+	fi
+
+	. /system/sdcard/config/recording.conf
+	if [ "$ROLL_RECORDING_ENABLE" = true ]; then
+		find $DCIM_PATH -mmin +${ROLL_RECORDING_RETENTION_MINUTES} -name "REC*" -delete
+		/system/sdcard/controlscripts/recording stop
+		/system/sdcard/controlscripts/recording start
+	fi
+}
+
+if [ $# -eq 0 ]; then
+  roll
+else
+  case $1 in roll)
+	  $1
+	  ;;
+  esac
+fi

--- a/firmware_mod/www/camera.html
+++ b/firmware_mod/www/camera.html
@@ -84,6 +84,21 @@
     </div>
         <p></p>
   </div>
+  <!-- Recording accordion -->
+  <button class="accordion" type='button'>Recording</button>
+  <div class="panel">
+    <p></p>
+    <label>Enable Recording Rollover (save recording to new file every 30 minutes)</label>
+    <select id="recordingRollover" class="w3-select" name="option">
+      <option value="true">Enabled</option>
+      <option value="false">Disabled</option>
+    </select>
+    <br />
+    <label>Recording retention (minutes):</label>
+    <input id="recordingRetention" class="w3-input" type="text">
+    <p></p>
+    
+  </div>
   <!-- Network / Security accordion -->
   <button class="accordion" type='button'>Network / Security</button>
   <div class="panel">

--- a/firmware_mod/www/cgi-bin/ui_camera.cgi
+++ b/firmware_mod/www/cgi-bin/ui_camera.cgi
@@ -15,6 +15,7 @@ if [ -n "$F_cmd" ]; then
   case "$F_cmd" in
   get_config)
   	source /system/sdcard/config/rtspserver.conf
+  	source /system/sdcard/config/recording.conf
 	source /system/sdcard/config/autonight.conf
 	source /system/sdcard/config/ldr-average.conf
 	source /system/sdcard/config/timelapse.conf
@@ -27,6 +28,8 @@ if [ -n "$F_cmd" ]; then
 	echo "format#:#${VIDEOFORMAT}"
 	echo "frmRateNum#:#${FRAMERATE_NUM}"
 	echo "frmRateDen#:#${FRAMERATE_DEN}"
+	echo "recordingRollover#:#${ROLL_RECORDING_ENABLE}"
+	echo "recordingRetention#:#${ROLL_RECORDING_RETENTION_MINUTES}"
 	echo "videoUser#:#${USERNAME}"
 	echo "videoPassword#:#${USERPASSWORD}"
 	echo "videoPort#:#${PORT}"
@@ -90,6 +93,16 @@ if [ -n "$F_cmd" ]; then
 		fi
 		echo "FrameRate set to $frmRateDen/$frmRateNum <br/>"
 		/system/sdcard/bin/setconf -k d -v "$frmRateNum,$frmRateDen" 2>/dev/null
+	fi
+	if [ -n  "${F_recordingRollover+x}" ]; then
+		recordingRollover=$(printf '%b' "${F_recordingRollover//%/\\x}")
+		rewrite_config /system/sdcard/config/recording.conf ROLL_RECORDING_ENABLE "$recordingRollover"
+		echo "Recording rollover enable toggle set to: $recordingRollover <br/>"
+	fi
+	if [ -n  "${F_recordingRetention+x}" ]; then
+		recordingRetention=$(printf '%b' "${F_recordingRetention//%/\\x}")
+		rewrite_config /system/sdcard/config/recording.conf ROLL_RECORDING_RETENTION_MINUTES "$recordingRetention"
+		echo "Recording retention in minutes set to: $recordingRetention <br/>"
 	fi
 	if [ -n  "${F_videoUser+x}" ]; then
 		videouser=$(printf '%b' "${F_videoUser//%/\\x}")


### PR DESCRIPTION
For me recording is important, because the motion detection is somewhat unreliable.
Having one large file is problematic, not to mention it will keep recording to that file forever.

With this pull request, the recording output file will be changed once every 30 minutes.

- implemented using cron
- roll every 30 minutes, not configurable via web (crontab)
- on/off toggle is configurable via web UI
- retention duration is configurable via web UI

TL;DR implementation: simply restarting the recording service once every 30 minutes, because actually splitting the file maybe impossible for some devices (mine only have 1MB free memory)