### PR TITLE
Add full support for Matrix image and video #1756

### DIFF
--- a/firmware_mod/bin/matrix
+++ b/firmware_mod/bin/matrix
@@ -1,18 +1,54 @@
 #!/bin/sh
 
+CURL="/system/sdcard/bin/curl --silent"
+JQ="/system/sdcard/bin/jq"
+
 what="$1"
-shift
-data="$@"
-CURL="/system/sdcard/bin/curl"
+
+if [ "$what" = "m" ]; then
+  shift
+  sendtext="${@//\"/\\\"}"
+else
+  filename="$2"
+  datafile="$3"
+fi
 
 . /system/sdcard/config/matrix.conf
 
-sendMessage() {
-  text="$(echo "${@}" | sed 's:\\n:\n:g')"
-  echo "Sending message: $text"
+uploadData() {
+  mimetype="$1"
+  msgtype="$2"
 
-  $CURL -XPOST -d '{"msgtype":"m.text", "body":"'$text'"}' "https://$host:$port/_matrix/client/r0/rooms/$room_id/send/m.room.message?access_token=$access_token"
+  mxcuri="$($CURL -XPOST -H "Content-Type: $mimetype" --data-binary @"$datafile" "https://$host:$port/_matrix/media/r0/upload?filename=$filename&access_token=$access_token" | $JQ -cMr ".content_uri")"
+  if [ -n "$mxcuri" ] && [ "$mxcuri" != "null" ]; then
+    $CURL -XPOST -d '{"msgtype":"'"$msgtype"'", "body":"'"$filename"'", "url":"'"$mxcuri"'"}' "https://$host:$port/_matrix/client/r0/rooms/$room_id/send/m.room.message?access_token=$access_token"
+  fi
 }
 
-[ "$what" = "m" ] && sendMessage $data
-[ -z "$what" ] && echo -e "$0 <m|f|p> <data>\n m: message\n f: file\n p: picture"
+sendFile() {
+  echo "Sending file: $datafile"
+  uploadData "application/octet-stream" "m.file"
+}
+
+sendMessage() {
+  echo "Sending message: $sendtext"
+  $CURL -XPOST -d '{"msgtype":"m.notice", "body":"'"$sendtext"'"}' "https://$host:$port/_matrix/client/r0/rooms/$room_id/send/m.room.message?access_token=$access_token"
+}
+
+sendPicture() {
+  echo "Sending picture: $datafile"
+  filename="$filename.jpg"
+  uploadData "image/jpeg" "m.image"
+}
+
+sendVideo() {
+  echo "Sending video: $datafile"
+  filename="$filename.mp4"
+  uploadData "video/mp4" "m.video"
+}
+
+[ "$what" = "f" ] && sendFile
+[ "$what" = "m" ] && sendMessage
+[ "$what" = "p" ] && sendPicture
+[ "$what" = "v" ] && sendVideo
+[ -z "$what" ] && echo -e "$0 <m|f|p|v> <data|filename>\n m: message\n f: file\n p: picture\n v: video"

--- a/firmware_mod/config/motion.conf.dist
+++ b/firmware_mod/config/motion.conf.dist
@@ -24,6 +24,7 @@ send_email=false
 send_telegram=false
 telegram_alert_type=image
 send_matrix=false
+matrix_alert_type=image
 night_mode_event_delay=30
 
 # General

--- a/firmware_mod/www/cgi-bin/ui_motion.cgi
+++ b/firmware_mod/www/cgi-bin/ui_motion.cgi
@@ -57,6 +57,7 @@ if [ -n "$F_cmd" ]; then
     echo "sendTelegram#:#${send_telegram}"
     echo "telegramAlertType#:#${telegram_alert_type}"
     echo "sendMatrix#:#${send_matrix}"
+    echo "matrixAlertType#:#${matrix_alert_type}"
     echo "nightModeEventDelay#:#${night_mode_event_delay}"
 
 	;;
@@ -257,6 +258,11 @@ if [ -n "$F_cmd" ]; then
 		F_sendMatrix=$(printf '%b' "${F_sendMatrix//%/\\x}")
 	    rewrite_config /system/sdcard/config/motion.conf send_matrix $F_sendMatrix
 		  echo "Send Matrix on motion set to $F_sendMatrix<br/>"
+	  fi
+    if [ -n "${F_matrixAlertType+x}" ]; then
+	    F_matrixAlertType=$(printf '%b' "${F_matrixAlertType//%/\\x}")
+	    rewrite_config /system/sdcard/config/motion.conf matrix_alert_type $F_matrixAlertType
+		  echo "Matrix alert type set to $F_matrixAlertType<br/>"
 	  fi
     if [ -n "${F_nightModeEventDelay+x}" ]; then
   		F_nightModeEventDelay=$(printf '%b' "${F_nightModeEventDelay//%/\\x}")

--- a/firmware_mod/www/motion.html
+++ b/firmware_mod/www/motion.html
@@ -318,6 +318,15 @@
         </select>
     </div>
     <div class="w3-container">
+        <label>Matrix alert type</label>
+        <select id="matrixAlertType" class="w3-select" name="option">
+            <option value="text">Text</option>
+            <option value="image">Image</option>
+            <option value="video">Video</option>
+            <option value="video+image">Video and Image</option>
+        </select>
+    </div>
+    <div class="w3-container">
         <label>Night mode delay (ignore motion events for 'delay' seconds after switching to night mode)</label>
         <input class="w3-input" id="nightModeEventDelay" type="number" size="6">
     </div>


### PR DESCRIPTION
Only issue is with the video when _not_ using RTSP/H.264. The Element/Android
Matrix app can play the converted mjpeg->DIVX video but the web page/browser
can not. We need support for H.264 and/or VP8/9 in `avconv` for that.