### PR TITLE
Add proper firmware image for Neos Smartcam

### DIFF
--- a/hacks/firmware/create_hacked_firmware_neos_smartcam.sh
+++ b/hacks/firmware/create_hacked_firmware_neos_smartcam.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+FIRMWARE_ROOT=$(pwd)/../../firmware_original/Neos_Smartcam/Orig_4.15.2.45/
+TMPDIR=./rootfs
+OUTFILE=./rootfs.bin
+rm -r $TMPDIR $OUTFILE
+unsquashfs -d $TMPDIR $FIRMWARE_ROOT/rootfs.bin
+cp ./rcfile.sh $TMPDIR/etc/init.d/rcS
+mksquashfs $TMPDIR $OUTFILE -b 131072 -comp xz -Xdict-size 100%
+./packer.py $FIRMWARE_ROOT/kernel.bin $OUTFILE $FIRMWARE_ROOT/driver.bin $FIRMWARE_ROOT/appfs.bin firmware_hacked.bin
+rm -r $TMPDIR $OUTFILE

--- a/hacks/install_cfw.md
+++ b/hacks/install_cfw.md
@@ -6,7 +6,8 @@
     --- | --- 
     [Xiaomi DaFang](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/raw/master/hacks/cfw/dafang/cfw-1.3.bin) | d45826d5b471564366b3b9435509df7e8a2c0720656ea2b4bcac6dd0b42cc3eb
     [Xiaomi XiaoFang T20](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/raw/master/hacks/cfw/xiaofang/cfw-1.0.bin) | 333053c3e98af24e0e90746d95e310a3c65b61f697288f974b702a5bcbba48a9
-    [Wyzecam V2/Neos SmartCam](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/raw/master/hacks/cfw/wyzecam_v2/cfw-1.2.bin) | 3b2deb32d0cd3ef75afef8788854883d868c09cf78c690f4b78fc26862793af3
+    [Wyzecam V2](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/raw/master/hacks/cfw/wyzecam_v2/cfw-1.2.bin) | 3b2deb32d0cd3ef75afef8788854883d868c09cf78c690f4b78fc26862793af3
+    [Neos SmartCam](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/raw/master/hacks/cfw/neos_smartcam/cfw-1.0.bin) | 141072077ad12e343d90c7905d0f747e5dfa07853f013328638fb16cbe26a2cd
     [Wyzecam Pan](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/raw/master/hacks/cfw/wyzecam_pan/cfw-1.0.bin) | f76990d187e763f160f5ad39331d6a3209d3025fe3719cb43c92dbad92cebba2
     Xiaomi XiaoFang T20L | [Start here](/hacks/install_cfw_t20l.md)
     Sannce & clones | [Start here](/hacks/install_sannce.md)


### PR DESCRIPTION
* Create a modified firmware image based on the original neos firmware so people can boot back to the Neos firmware instead of booting to the Wyze firmware.