### PR TITLE
Add stream URLs and MQTT messages to documentation

### DIFF
--- a/hacks/faq.md
+++ b/hacks/faq.md
@@ -61,5 +61,43 @@ Recording Audio:
 
 - Any additional software that you may want can be compiled separately, and there is a toolchain available but you will need to do this yourself.
 
+### What are the URLs I can use to integrate with the camera?
+| Type | URLs |
+| --- | --- |
+| RTSP video stream | `rtsp://dafang/unicast` |
+| HTTP live streaming | (not available) |
+| Current image (image/jpeg) | `https://dafang/cgi-bin/currentpic.cgi` |
+| Get camera state | `https://dafang/cgi-bin/state.cgi?cmd=all` |
+| Get system info | `https://dafang/cgi-bin/api.cgi?action=systeminfo` |
+
+### What MQTT messages does the camera use?
+Sent by the camera
+| MQTT topic | Comments |
+| --- | --- |
+| `<location>/<device_name>/motion` | Motion detection status. Payload is either `ON` or `OFF`. |
+| `<discovery_prefix>/<entity_type/<device_name>/<entity_name>/config` | Home Assistant MQTT auto discovery messages. More info: https://www.home-assistant.io/docs/mqtt/discovery/ |
+| `<location>/<device_name>/leds/blue` <br /> `<location>/<device_name>/leds/yellow` <br /> `<location>/<device_name>/leds/ir` <br /> `<location>/<device_name>/ir_cut` <br /> `<location>/<device_name>/rtsp_server` <br /> `<location>/<device_name>/night_mode` <br /> `<location>/<device_name>/night_mode/auto` <br /> `<location>/<device_name>/recording` <br /> `<location>/<device_name>/timelapse` | Camera configuration and status. Payload is either `ON` or `OFF` |
+
+
+```
+<location>/<device_name>/motion/detection
+<location>/<device_name>/motion/led
+<location>/<device_name>/motion/snapshot
+<location>/<device_name>/motion/video
+<location>/<device_name>/motion/mqtt_publish
+<location>/<device_name>/motion/mqtt_snapshot
+<location>/<device_name>/motion/send_mail
+<location>/<device_name>/motion/send_telegram
+<location>/<device_name>/motion/tracking
+``` | Motion detection configuration. Payload is either `ON` or `OFF` |
+| `<location>/<device_name>/brightness` | Unknown |
+
+
+
+Received by the camera
+| MQTT topic | Comments |
+| 
+
+
 ### What if my scripts in config/userscripts/motiondetection are not executed or mqtt/telegram messages/emails are not sent on motion?
 Your camera probably runs out of memory when processing the motion event. This is likely in cameras with 64MB e.g. the Xiaofang 1s. Try to [enable some swap memory](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/blob/master/firmware_mod/config/swap.conf.dist#L4) by copying `swap.conf.dist` to `swap.conf` and setting `SWAP=true`.

--- a/hacks/faq.md
+++ b/hacks/faq.md
@@ -70,34 +70,36 @@ Recording Audio:
 | Get camera state | `https://dafang/cgi-bin/state.cgi?cmd=all` |
 | Get system info | `https://dafang/cgi-bin/api.cgi?action=systeminfo` |
 
+### What if my scripts in config/userscripts/motiondetection are not executed or mqtt/telegram messages/emails are not sent on motion?
+Your camera probably runs out of memory when processing the motion event. This is likely in cameras with 64MB e.g. the Xiaofang 1s. Try to [enable some swap memory](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/blob/master/firmware_mod/config/swap.conf.dist#L4) by copying `swap.conf.dist` to `swap.conf` and setting `SWAP=true`.
+
 ### What MQTT messages does the camera use?
-Sent by the camera
+#### Sent by the camera
 | MQTT topic | Comments |
 | --- | --- |
+| `<location>/<device_name>/`| General device status |
 | `<location>/<device_name>/motion` | Motion detection status. Payload is either `ON` or `OFF`. |
 | `<discovery_prefix>/<entity_type/<device_name>/<entity_name>/config` | Home Assistant MQTT auto discovery messages. More info: https://www.home-assistant.io/docs/mqtt/discovery/ |
 | `<location>/<device_name>/leds/blue` <br /> `<location>/<device_name>/leds/yellow` <br /> `<location>/<device_name>/leds/ir` <br /> `<location>/<device_name>/ir_cut` <br /> `<location>/<device_name>/rtsp_server` <br /> `<location>/<device_name>/night_mode` <br /> `<location>/<device_name>/night_mode/auto` <br /> `<location>/<device_name>/recording` <br /> `<location>/<device_name>/timelapse` | Camera configuration and status. Payload is either `ON` or `OFF` |
+| `<location>/<device_name>/motion/detection` <br/ > `<location>/<device_name>/motion/led` <br/ > `<location>/<device_name>/motion/snapshot` <br/ > `<location>/<device_name>/motion/video` <br/ > `<location>/<device_name>/motion/mqtt_publish` <br/ > `<location>/<device_name>/motion/mqtt_snapshot` <br/ > `<location>/<device_name>/motion/send_mail` <br/ > `<location>/<device_name>/motion/send_telegram` <br/ > `<location>/<device_name>/motion/tracking` | Motion detection configuration. Payload is either `ON` or `OFF` |
+| `<location>/<device_name>/motion/snapshot/image` | Sending an image via MQTT when motion is detected. |
+| `<location>/<device_name>/motion/video` | Sending an video via MQTT when motion is detected. |
+| `<location>/<device_name>/brightness` | Brigtness level, given as a percentage. Disabled by default. |
+| `<location>/<device_name>/motors/vertical` <br/> `<location>/<device_name>/motors/horizontal` | Status of motors and alignment |
 
-
-```
-<location>/<device_name>/motion/detection
-<location>/<device_name>/motion/led
-<location>/<device_name>/motion/snapshot
-<location>/<device_name>/motion/video
-<location>/<device_name>/motion/mqtt_publish
-<location>/<device_name>/motion/mqtt_snapshot
-<location>/<device_name>/motion/send_mail
-<location>/<device_name>/motion/send_telegram
-<location>/<device_name>/motion/tracking
-``` | Motion detection configuration. Payload is either `ON` or `OFF` |
-| `<location>/<device_name>/brightness` | Unknown |
-
-
-
-Received by the camera
+#### Received by the camera
 | MQTT topic | Comments |
-| 
-
-
-### What if my scripts in config/userscripts/motiondetection are not executed or mqtt/telegram messages/emails are not sent on motion?
-Your camera probably runs out of memory when processing the motion event. This is likely in cameras with 64MB e.g. the Xiaofang 1s. Try to [enable some swap memory](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/blob/master/firmware_mod/config/swap.conf.dist#L4) by copying `swap.conf.dist` to `swap.conf` and setting `SWAP=true`.
+| --- | --- |
+| `<discovery_prefix>/set` | Trigger Home Assistant MQTT auto discovery announcement |
+| `<location>/<device_name>/set status` | Get the device's system status |
+| `<location>/<device_name>/play` | Play the audio file configured in the camera's settings |
+| `<location>/<device_name>/leds/blue` | Get the device's system status |
+| `<location>/<device_name>/timelapse/set` <br/> `<location>/<device_name>/recording/set` <br/> `<location>/<device_name>/rtsp_server/set` <br/> `<location>/<device_name>/rtsp_server/set` <br/> `<location>/<device_name>/night_mode/set` <br/> `<location>/<device_name>/night_mode/auto/set` <br/> `<location>/<device_name>/ir_cut/set` <br/> `<location>/<device_name>/leds/ir/set` <br/> `<location>/<device_name>/leds/yellow/set` <br/> `<location>/<device_name>/leds/blue/set` <br/> `<location>/<device_name>/motion/tracking/set` <br/> `<location>/<device_name>/motion/send_mail/set` <br/> `<location>/<device_name>/motion/detection/set` <br/> `<location>/<device_name>/motion/send_telegram/set` <br/> `<location>/<device_name>/motion/snapshot/set` <br/> `<location>/<device_name>/motion/video/set` <br/> `<location>/<device_name>/motion/mqtt_publish/set` <br/> `<location>/<device_name>/motion/mqtt_snapshot/set` <br/> `<location>/<device_name>/motion/mqtt_snapshot/set` <br/>  | Enable or disable a setting. Payload must be `ON` or `OFF`. |
+| `<location>/<device_name>/snapshot/image GET` | Trigger a snapshot image to be sent over MQTT. |
+| `<location>/<device_name>/motors/horizontal/set` | Rotate the camera. Payload must be either `left` or `right`. |
+| `<location>/<device_name>/motors/vertical/set` | Rotate the camera. Payload must be either `up` or `down`. |
+| `<location>/<device_name>/motors/set calibrate` | Re-calibrate the motors. |
+| `<location>/<device_name>/remount_sdcard/set ON` | Remount the SD card. |
+| `<location>/<device_name>/reboot/set ON` | Reboot the camera. |
+| `<location>/<device_name>/update/set ON` | Update the camera's firmware. |
+| `<location>/<device_name>/set (command)` | Invoke the command using `/system/sdcard/www/cgi-bin/action.cgi` |


### PR DESCRIPTION
I wanted to add details to the documentation if you're happy with it:
- the different video & picture URLs available.
- the different MQTT messages either sent or received by the camera.

I'm happy with any style or grammar changes if that works. Let me know what you think.