### PR TITLE
Add details to configure WPA2 Wi-Fi set-up

### DIFF
--- a/hacks/install_cfw.md
+++ b/hacks/install_cfw.md
@@ -95,6 +95,26 @@ network={
 }
 ```
 
+If your Wi-Fi WPA setup uses protocol WPA2, add proto=WPA2 under ssid=
+```
+ctrl_interface=/var/run/wpa_supplicant
+ctrl_interface_group=0
+ap_scan=1
+
+network={
+ssid="enteryourssidherebutrememebertokeepthequotes"
+        # Uncomment to connect to Hidden SSIDs
+        #scan_ssid=1
+        key_mgmt=WPA-PSK
+        pairwise=CCMP TKIP
+        group=CCMP TKIP WEP104 WEP40
+        psk="enteryourpasswordherebutremembertokeepthequotes"
+        priority=2
+        proto=WPA2
+}
+```
+
+
 5. Inspect you sdcard for logs/startup.log
 
 ### Advanced Installation


### PR DESCRIPTION
No remark about proto=WPA2 in the previous example was confusing as the camera would not connect to the Wi-Fi network