### PR TITLE
Prevent HTTPS redirects for 127.0.0.1

### DIFF
--- a/firmware_mod/config/lighttpd.conf.dist
+++ b/firmware_mod/config/lighttpd.conf.dist
@@ -52,10 +52,13 @@ $HTTP["url"] !~ "^/.well-known/(.*)" {
 #SSL is enabled by default
 #If disabling SSL you must clear your site cookie
 	$HTTP["scheme"] == "http" {
-		# capture vhost name with regex conditiona -> %0 in redirect pattern
-		# must be the most inner block to the redirect rule
-		$HTTP["host"] =~ ".*" {
-			url.redirect = (".*" => "https://%0$0")
+		# Do not apply rule to 127.0.0.1, for ssh tunnels
+		$HTTP["remote-ip"] != "127.0.0.1" {
+			# capture vhost name with regex conditiona -> %0 in redirect pattern
+			# must be the most inner block to the redirect rule
+			$HTTP["host"] =~ ".*" {
+				url.redirect = (".*" => "https://%0$0")
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is helpful for when a host is connected over an ssh tunnel, and sends "localhost" for the HOST header. If it is an ssh tunnel, it is already secured. And browsers have trouble with redirects to https://localhost

That means that a user can set up an ssh `ssh -L 8080:localhost:80 dafang.local, and then view the camera with http://localhost:8080`

Currently, it will try try to redirect the client to https://localhost:8080, which fails.

I came up with this when I had to use ssh jump hosts to connect to specific cameras behind a bastion server. And I think it is safe to assume that localhost does not require encryption.