### PR TITLE
Multiple fixes & improvements related to volume and audio.

### DIFF
--- a/firmware_mod/scripts/common_functions.sh
+++ b/firmware_mod/scripts/common_functions.sh
@@ -881,3 +881,31 @@ wpa_config_get() {
 		grep "^[[:space:]]*$key=" "$wpa_config" | cut -d "=" -f2
 	fi
 }
+
+# Control the hw volume
+hwvolume() {
+	if [[ "$1" == "status" ]]; then
+		# Get the current volume value
+		local raw=$(/system/sdcard/bin/setconf -g h)
+		echo "$(busybox expr ${raw} \* 100 / 120)"
+	else
+		# Set the new volume value
+		local scaled=$(busybox expr $1 \* 120 / 100)
+		/system/sdcard/bin/setconf -k h -v "$scaled"
+		rewrite_config /system/sdcard/config/rtspserver.conf HWVOLUME "$scaled"
+  fi
+}
+
+# Control the hw volume
+swvolume() {
+	if [[ "$1" == "status" ]]; then
+		# Get the current volume value
+		local raw=$(/system/sdcard/bin/setconf -g i)
+		echo "$(busybox expr ${raw} \* 100 / 1000)"
+	else
+		# Set the new volume value
+		local scaled=$(busybox expr $1 \* 1000 / 100)
+		/system/sdcard/bin/setconf -k i -v "$scaled"
+		rewrite_config /system/sdcard/config/rtspserver.conf SWVOLUME "$scaled"
+  fi
+}

--- a/firmware_mod/scripts/mqtt-autodiscovery.sh
+++ b/firmware_mod/scripts/mqtt-autodiscovery.sh
@@ -76,3 +76,9 @@
 
   # Timelapse on/off switch
   $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/timelapse/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Timelapse\", \"unique_id\": \"$MAC_SIMPLE-timelapse\", $DEVICE_INFO, \"icon\": \"mdi:image-multiple\", \"state_topic\": \"$TOPIC/timelapse\", \"command_topic\": \"$TOPIC/timelapse/set\"}"
+  
+  # HW Volume
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/number/$DEVICE_NAME/hwvolume/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME HW Volume\", \"unique_id\": \"$MAC_SIMPLE-hwvolume\", $DEVICE_INFO, \"icon\": \"mdi:volume-high\", \"min\": 0, \"max\": 100, \"step\": 1, \"unit_of_measurement\": \"%\", \"state_topic\": \"$TOPIC/hwvolume\", \"command_topic\": \"$TOPIC/hwvolume/set\"}"
+  
+  # SW Volume
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/number/$DEVICE_NAME/swvolume/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME SW Volume\", \"unique_id\": \"$MAC_SIMPLE-swvolume\", $DEVICE_INFO, \"icon\": \"mdi:volume-source\", \"min\": 0, \"max\": 100, \"step\": 1, \"unit_of_measurement\": \"%\", \"state_topic\": \"$TOPIC/swvolume\", \"command_topic\": \"$TOPIC/swvolume/set\"}"

--- a/firmware_mod/scripts/mqtt-control.sh
+++ b/firmware_mod/scripts/mqtt-control.sh
@@ -434,6 +434,26 @@ done
 	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/update ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -m "Upgrade finish: ${result}"	  
 	;;
 
+	"${TOPIC}/hwvolume")
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/hwvolume ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(hwvolume status)"
+	;;
+
+	"${TOPIC}/hwvolume/set"*)
+		VOLUME=$(echo "$line" | awk '{print $2}')
+		hwvolume "$VOLUME"
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/hwvolume ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(hwvolume status)"
+	;;
+
+	"${TOPIC}/swvolume")
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/swvolume ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(swvolume status)"
+	;;
+
+	"${TOPIC}/swvolume/set"*)
+		VOLUME=$(echo "$line" | awk '{print $2}')
+		swvolume "$VOLUME"
+	  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/swvolume ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -m "$(swvolume status)"
+	;;
+
 	"${TOPIC}/set "*)
 	  COMMAND=$(echo "$line" | awk '{print $2}')
 	  #echo "$COMMAND"

--- a/firmware_mod/scripts/mqtt-status-interval.sh
+++ b/firmware_mod/scripts/mqtt-status-interval.sh
@@ -50,5 +50,7 @@ do
   fi
   /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/motors/horizontal ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "$TARGET"
   /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}" ${MOSQUITTOOPTS} ${MOSQUITTOPUBOPTS} -r -m "$(/system/sdcard/scripts/mqtt-status.sh)"
+  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/hwvolume ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "$(hwvolume status)"
+  /system/sdcard/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/swvolume ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "$(swvolume status)"
   sleep $STATUSINTERVAL
 done

--- a/firmware_mod/www/camera.html
+++ b/firmware_mod/www/camera.html
@@ -151,8 +151,12 @@
         </select>
       </div>
       <div class="w3-half">
-        <label>Volume</label><br />
-        <input name="audioinVol" step="1" min="-1" max="120" type="range" class="w3-input"> 
+        <label>HW Volume</label><br />
+        <input id="audioinHWVol" step="1" min="-1" max="120" type="range" class="w3-input"> 
+      </div>
+      <div class="w3-half">
+        <label>SW Volume</label><br />
+        <input id="audioinSWVol" step="1" min="-1" max="1000" type="range" class="w3-input"> 
       </div>
     </div>
     <p></p>

--- a/firmware_mod/www/cgi-bin/action.cgi
+++ b/firmware_mod/www/cgi-bin/action.cgi
@@ -514,8 +514,8 @@ auto_night_mode_status)
 	rewrite_config /system/sdcard/config/rtspserver.conf FILTER "$F_audioinFilter"
 	rewrite_config /system/sdcard/config/rtspserver.conf HIGHPASSFILTER "$F_HFEnabled"
 	rewrite_config /system/sdcard/config/rtspserver.conf AECFILTER "$F_AECEnabled"
-	rewrite_config /system/sdcard/config/rtspserver.conf HWVOLUME "$F_audioinVol"
-	rewrite_config /system/sdcard/config/rtspserver.conf SWVOLUME "-1"
+	rewrite_config /system/sdcard/config/rtspserver.conf HWVOLUME "$F_audioinHWVol"
+	rewrite_config /system/sdcard/config/rtspserver.conf SWVOLUME "$F_audioinSWVol"
 
 	echo "Audio format $audioinFormat <br/>"
 	echo "In audio bitrate $audioinBR <br/>"
@@ -523,11 +523,13 @@ auto_night_mode_status)
 	echo "Filter $F_audioinFilter <br/>"
 	echo "High Pass Filter $F_HFEnabled <br/>"
 	echo "AEC Filter $F_AECEnabled <br/>"
-	echo "Volume $F_audioinVol <br/>"
+	echo "HW Volume $F_audioinHWVol <br/>"
+	echo "SW Volume $F_audioinSWVol <br/>"
 	/system/sdcard/bin/setconf -k q -v "$F_audioinFilter" 2>/dev/null
 	/system/sdcard/bin/setconf -k l -v "$F_HFEnabled" 2>/dev/null
 	/system/sdcard/bin/setconf -k a -v "$F_AECEnabled" 2>/dev/null
-	/system/sdcard/bin/setconf -k h -v "$F_audioinVol" 2>/dev/null
+	/system/sdcard/bin/setconf -k h -v "$F_audioinHWVol" 2>/dev/null
+	/system/sdcard/bin/setconf -k i -v "$F_audioinSWVol" 2>/dev/null
 	return
   ;;
 

--- a/firmware_mod/www/cgi-bin/ui_camera.cgi
+++ b/firmware_mod/www/cgi-bin/ui_camera.cgi
@@ -286,8 +286,9 @@ if [ -n "$F_cmd" ]; then
 		echo "SWVolume $F_audioinSWVol <br/>"
 		/system/sdcard/bin/setconf -k i -v "$F_audioinSWVol" 2>/dev/null
 	fi
-	if [ -n  "${F_frmRateDen+x}" ]; then
+	if [ -n  "${F_frmRateDen+x}" ] && [ -n "${F_frmRateNum+x}" ]; then
 		frmRateDen=$(printf '%b' "${F_frmRateDen/%/\\x}")
+		frmRateNum=$(printf '%b' "${F_frmRateNum/%/\\x}")
 		echo "FrameRate set to $frmRateDen/$frmRateNum <br/>"
 		/system/sdcard/bin/setconf -k d -v "$frmRateNum,$frmRateDen" 2>/dev/null
 	fi

--- a/firmware_mod/www/cgi-bin/ui_camera.cgi
+++ b/firmware_mod/www/cgi-bin/ui_camera.cgi
@@ -38,7 +38,8 @@ if [ -n "$F_cmd" ]; then
 	echo "audioinFilter#:#$(/system/sdcard/bin/setconf -g q)"
 	echo "HFEnabled#:#$(/system/sdcard/bin/setconf -g l)"
 	echo "AECEnabled#:#$(/system/sdcard/bin/setconf -g a)"
-	echo "audioinVol#:#$(/system/sdcard/bin/setconf -g h)"
+	echo "audioinHWVol#:#$(/system/sdcard/bin/setconf -g h)"
+	echo "audioinSWVol#:#$(/system/sdcard/bin/setconf -g i)"
 	echo "tlinterval#:#${TIMELAPSE_INTERVAL}"
 	echo "tlduration#:#${TIMELAPSE_DURATION}"
 	echo "osdEnable#:#${ENABLE_OSD}"
@@ -154,7 +155,7 @@ if [ -n "$F_cmd" ]; then
 	if [ -n  "${F_audioinFilter+x}" ]; then
 		rewrite_config /system/sdcard/config/rtspserver.conf FILTER "$F_audioinFilter"
 		echo "Filter $F_audioinFilter <br/>"
-		system/sdcard/bin/setconf -k q -v "$F_audioinFilter" 2>/dev/null
+		/system/sdcard/bin/setconf -k q -v "$F_audioinFilter" 2>/dev/null
 	fi
 	if [ -n  "${F_HFEnabled+x}" ]; then
 		rewrite_config /system/sdcard/config/rtspserver.conf HIGHPASSFILTER "$F_HFEnabled"
@@ -166,11 +167,15 @@ if [ -n "$F_cmd" ]; then
 		echo "AEC Filter $F_AECEnabled <br/>"
 		/system/sdcard/bin/setconf -k a -v "$F_AECEnabled" 2>/dev/null
 	fi
-	if [ -n  "${F_audioinVol+x}" ]; then
-		rewrite_config /system/sdcard/config/rtspserver.conf HWVOLUME "$F_audioinVol"
-		rewrite_config /system/sdcard/config/rtspserver.conf SWVOLUME "-1"
-		echo "Volume $F_audioinVol <br/>"
-		/system/sdcard/bin/setconf -k h -v "$F_audioinVol" 2>/dev/null
+	if [ -n  "${F_audioinHWVol+x}" ]; then
+		rewrite_config /system/sdcard/config/rtspserver.conf HWVOLUME "$F_audioinHWVol"
+		echo "HWVolume $F_audioinHWVol <br/>"
+		/system/sdcard/bin/setconf -k h -v "$F_audioinHWVol" 2>/dev/null
+	fi
+	if [ -n  "${F_audioinSWVol+x}" ]; then
+		rewrite_config /system/sdcard/config/rtspserver.conf SWVOLUME "$F_audioinSWVol"
+		echo "SWVolume $F_audioinSWVol <br/>"
+		/system/sdcard/bin/setconf -k i -v "$F_audioinSWVol" 2>/dev/null
 	fi
 	if [ -n  "${F_tlinterval+x}" ]; then
 		tlinterval=$(printf '%b' "${F_tlinterval/%/\\x}")
@@ -259,6 +264,68 @@ if [ -n "$F_cmd" ]; then
 	  /system/sdcard/controlscripts/rtsp start
 	fi
 	return
+	;;
+  set_config_live)
+	if [ -n  "${F_audioinFilter+x}" ]; then
+		echo "Filter $F_audioinFilter <br/>"
+		/system/sdcard/bin/setconf -k q -v "$F_audioinFilter" 2>/dev/null
+	fi
+	if [ -n  "${F_HFEnabled+x}" ]; then
+		echo "High Pass Filter $F_HFEnabled <br/>"
+		/system/sdcard/bin/setconf -k l -v "$F_HFEnabled" 2>/dev/null
+	fi
+	if [ -n  "${F_AECEnabled+x}" ]; then
+		echo "AEC Filter $F_AECEnabled <br/>"
+		/system/sdcard/bin/setconf -k a -v "$F_AECEnabled" 2>/dev/null
+	fi
+	if [ -n  "${F_audioinHWVol+x}" ]; then
+		echo "HWVolume $F_audioinHWVol <br/>"
+		/system/sdcard/bin/setconf -k h -v "$F_audioinHWVol" 2>/dev/null
+	fi
+	if [ -n  "${F_audioinSWVol+x}" ]; then
+		echo "SWVolume $F_audioinSWVol <br/>"
+		/system/sdcard/bin/setconf -k i -v "$F_audioinSWVol" 2>/dev/null
+	fi
+	if [ -n  "${F_frmRateDen+x}" ]; then
+		frmRateDen=$(printf '%b' "${F_frmRateDen/%/\\x}")
+		echo "FrameRate set to $frmRateDen/$frmRateNum <br/>"
+		/system/sdcard/bin/setconf -k d -v "$frmRateNum,$frmRateDen" 2>/dev/null
+	fi
+	if [ -n  "${F_osdColor+x}" ]; then
+		color='white black red green blue cyan yellow purple'
+		echo "COLOR=${F_osdColor}" >> /system/sdcard/config/osd.conf
+		/system/sdcard/bin/setconf -k c -v "${F_osdColor}"
+		echo -n "Set text color to "
+		echo -n $(echo $color | cut -d ' ' -f $(($F_osdColor + 1)))
+		echo "<br />"
+	fi
+	if [ -n  "${F_osdSize+x}" ]; then
+		echo "SIZE=${F_osdSize}" >> /system/sdcard/config/osd.conf
+		/system/sdcard/bin/setconf -k s -v "${F_osdSize}"
+		echo "Set OSD text size to ${F_osdSize}<br />"
+	fi
+	if [ -n  "${F_osdPixel+x}" ]; then
+		echo "SPACE=${F_osdPixel}" >> /system/sdcard/config/osd.conf
+		/system/sdcard/bin/setconf -k p -v "${F_osdPixel}"
+		echo "Set OSD pixel between chars to ${F_osdPixel}<br />"
+	fi
+	if [ -n  "${F_osdY+x}" ]; then
+		echo "POSY=${F_osdY}" >> /system/sdcard/config/osd.conf
+		/system/sdcard/bin/setconf -k x -v "${F_osdY}"
+		echo "Set OSD Y position to ${F_osdY}<br />"
+	fi
+	if [ -n  "${F_osdFixW+x}" ]; then
+		echo "FIXEDW=${F_osdFixW}" >> /system/sdcard/config/osd.conf
+		/system/sdcard/bin/setconf -k w -v "${F_osdFixW}"
+		echo "Set OSD fixed width to ${F_osdFixW}<br />"
+	fi
+	if [ -n  "${F_osdFonts+x}" ]; then
+		fontName=$(printf '%b' "${F_osdFonts//%/\\x}")
+		fontName=$(echo "$fontName" | sed -e "s/\\+/ /g")
+		echo "FONTNAME=${fontName}" >> /system/sdcard/config/osd.conf
+		/system/sdcard/bin/setconf -k e -v "${fontName}"
+		echo "Set OSD font to ${fontName}<br />"
+	fi
 	;;
   *)
     echo "Unsupported command '$F_cmd'"

--- a/firmware_mod/www/js/camera.js
+++ b/firmware_mod/www/js/camera.js
@@ -21,7 +21,15 @@ function watchChanges(elements){
     $("#"+elements+" input, #"+elements+" select").on('change', function(e){
         var postData = { cmd: "set_config_live" }
         var input = $(e.target);
-        postData[input.attr('id')] = input.val();
+        var id = input.attr('id')
+        postData[id] = input.val();
+        if (id ==='frmRateDen'){
+            postData['frmRateNum'] = $("#frmRateNum").val();
+        }
+        postData[id] = input.val();
+        if (id === 'frmRateNum'){
+            postData['frmRateDen'] = $("#frmRateDen").val();
+        }
         $.post("cgi-bin/ui_camera.cgi",postData,function(result){
             console.log(result);
         });

--- a/firmware_mod/www/js/camera.js
+++ b/firmware_mod/www/js/camera.js
@@ -13,8 +13,19 @@ function saveConfig(elements) {
             $('#save_result').html(result);
         else
             $('#save_result').html("Nothing to update");
-    });
-    
+    });    
+}
+
+function watchChanges(elements){
+    //Callback for setting audio settings live
+    $("#"+elements+" input, #"+elements+" select").on('change', function(e){
+        var postData = { cmd: "set_config_live" }
+        var input = $(e.target);
+        postData[input.attr('id')] = input.val();
+        $.post("cgi-bin/ui_camera.cgi",postData,function(result){
+            console.log(result);
+        });
+    })
 }
 
 //Function get config
@@ -46,6 +57,11 @@ function onLoad() {
     accordion();
     //Get configuration
     getConfig();
+    //Watch for live changes
+    watchChanges('video')
+    watchChanges('audio')
+    watchChanges('timelapseF')
+    watchChanges('osd')
 
 }
 


### PR DESCRIPTION
## Fix setting HW Volume from web UI
* The input field had no ID, and the js script ignored that field

## Fix setting filter from web UI
* The path to setconf was wrong in ui_camera.cgi

## Expose SW volume in web UI
* This is useful for low volume cameras.
* Mine for example has very low sensitivity without SW volume turned up
![image](https://user-images.githubusercontent.com/777196/235305614-e6c78d74-375a-4a60-a246-734e2801a4cd.png)

## LIVE Update audio volume and filters, FPS and OSD settings from the Web UI
* Volume updates as soon as you release the mouse while scrolling the slider
* Without interrupting the stream
* It is not persisted unless one clicks save
* Useful for testing filters and volumes before saving

## Volumes (HW and SW) exposed via MQTT 
* Persisted
* Both scaled to appear as 0 to 100%
<img width="495" alt="image" src="https://user-images.githubusercontent.com/777196/235315666-9a4b09a7-cf74-45b6-912c-edfa85621202.png">

