### PR TITLE
Fix 2023.8 repair warning

### DIFF
--- a/firmware_mod/scripts/mqtt-autodiscovery.sh
+++ b/firmware_mod/scripts/mqtt-autodiscovery.sh
@@ -28,51 +28,51 @@
   DEVICE_INFO="\"device\": {\"identifiers\": \"$MAC_SIMPLE\", \"connections\": [[\"mac\", \"$MAC\"]], \"manufacturer\": \"$MANUFACTURER\", \"model\": \"$MODEL\", \"name\": \"$DEVICE_NAME\", \"sw_version\": \"$VER\"}"
 
   # Motion sensor
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/binary_sensor/$DEVICE_NAME/motion/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Motion Sensor\", \"unique_id\": \"$MAC_SIMPLE-motion-sensor\", $DEVICE_INFO, \"state_topic\": \"$TOPIC/motion\", \"device_class\": \"motion\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/binary_sensor/$DEVICE_NAME/motion/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Motion Sensor\", \"unique_id\": \"$MAC_SIMPLE-motion-sensor\", $DEVICE_INFO, \"state_topic\": \"$TOPIC/motion\", \"device_class\": \"motion\"}"
 
   # Motion detection on/off switch
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_detection/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Motion Detection\", \"unique_id\": \"$MAC_SIMPLE-motion-detection\", $DEVICE_INFO, \"icon\": \"mdi:motion-sensor\", \"state_topic\": \"$TOPIC/motion/detection\", \"command_topic\": \"$TOPIC/motion/detection/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_detection/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Motion Detection\", \"unique_id\": \"$MAC_SIMPLE-motion-detection\", $DEVICE_INFO, \"icon\": \"mdi:motion-sensor\", \"state_topic\": \"$TOPIC/motion/detection\", \"command_topic\": \"$TOPIC/motion/detection/set\"}"
 
   # Motion send mail alert on/off switch
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_send_mail/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Motion Send Emails\", \"unique_id\": \"$MAC_SIMPLE-motion-send-mail\", $DEVICE_INFO, \"icon\": \"mdi:email-arrow-right\", \"state_topic\": \"$TOPIC/motion/send_mail\", \"command_topic\": \"$TOPIC/motion/send_mail/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_send_mail/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Motion Send Emails\", \"unique_id\": \"$MAC_SIMPLE-motion-send-mail\", $DEVICE_INFO, \"icon\": \"mdi:email-arrow-right\", \"state_topic\": \"$TOPIC/motion/send_mail\", \"command_topic\": \"$TOPIC/motion/send_mail/set\"}"
 
   # Motion send telegram alert on/off switch
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_send_telegram/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Motion Send Telegram\", \"unique_id\": \"$MAC_SIMPLE-motion-send-telegram\", $DEVICE_INFO, \"icon\": \"mdi:send\", \"state_topic\": \"$TOPIC/motion/send_telegram\", \"command_topic\": \"$TOPIC/motion/send_telegram/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_send_telegram/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Motion Send Telegram\", \"unique_id\": \"$MAC_SIMPLE-motion-send-telegram\", $DEVICE_INFO, \"icon\": \"mdi:send\", \"state_topic\": \"$TOPIC/motion/send_telegram\", \"command_topic\": \"$TOPIC/motion/send_telegram/set\"}"
 
   # Motion detection snapshots
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/camera/$DEVICE_NAME/motion_snapshot/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Motion Snapshot\", \"unique_id\": \"$MAC_SIMPLE-motion-snapshot\", $DEVICE_INFO,\"topic\": \"$TOPIC/motion/snapshot/image\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/camera/$DEVICE_NAME/motion_snapshot/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Motion Snapshot\", \"unique_id\": \"$MAC_SIMPLE-motion-snapshot\", $DEVICE_INFO,\"topic\": \"$TOPIC/motion/snapshot/image\"}"
 
   # Motion tracking on/off switch
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_tracking/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Motion Tracking\", \"unique_id\": \"$MAC_SIMPLE-motion-tracking\", $DEVICE_INFO, \"icon\": \"mdi:track-light\", \"state_topic\": \"$TOPIC/motion/tracking\", \"command_topic\": \"$TOPIC/motion/tracking/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/motion_tracking/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Motion Tracking\", \"unique_id\": \"$MAC_SIMPLE-motion-tracking\", $DEVICE_INFO, \"icon\": \"mdi:track-light\", \"state_topic\": \"$TOPIC/motion/tracking\", \"command_topic\": \"$TOPIC/motion/tracking/set\"}"
 
   # LEDs
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/blue_led/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Blue LED\", \"unique_id\": \"$MAC_SIMPLE-blue-led\", $DEVICE_INFO, \"icon\": \"mdi:led-on\", \"state_topic\": \"$TOPIC/leds/blue\", \"command_topic\": \"$TOPIC/leds/blue/set\"}"
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/yellow_led/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Yellow LED\", \"unique_id\": \"$MAC_SIMPLE-yellow-led\", $DEVICE_INFO, \"icon\": \"mdi:led-on\", \"state_topic\": \"$TOPIC/leds/yellow\", \"command_topic\": \"$TOPIC/leds/yellow/set\"}"
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/ir_led/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME IR LED\", \"unique_id\": \"$MAC_SIMPLE-ir-led\", $DEVICE_INFO, \"icon\": \"mdi:led-on\", \"state_topic\": \"$TOPIC/leds/ir\", \"command_topic\": \"$TOPIC/leds/ir/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/blue_led/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Blue LED\", \"unique_id\": \"$MAC_SIMPLE-blue-led\", $DEVICE_INFO, \"icon\": \"mdi:led-on\", \"state_topic\": \"$TOPIC/leds/blue\", \"command_topic\": \"$TOPIC/leds/blue/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/yellow_led/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Yellow LED\", \"unique_id\": \"$MAC_SIMPLE-yellow-led\", $DEVICE_INFO, \"icon\": \"mdi:led-on\", \"state_topic\": \"$TOPIC/leds/yellow\", \"command_topic\": \"$TOPIC/leds/yellow/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/ir_led/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"IR LED\", \"unique_id\": \"$MAC_SIMPLE-ir-led\", $DEVICE_INFO, \"icon\": \"mdi:led-on\", \"state_topic\": \"$TOPIC/leds/ir\", \"command_topic\": \"$TOPIC/leds/ir/set\"}"
 
   # IR Filter
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/ir_cut/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME IR Filter\", \"unique_id\": \"$MAC_SIMPLE-ir-filter\", $DEVICE_INFO, \"icon\": \"mdi:image-filter-black-white\", \"state_topic\": \"$TOPIC/ir_cut\", \"command_topic\": \"$TOPIC/ir_cut/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/ir_cut/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"IR Filter\", \"unique_id\": \"$MAC_SIMPLE-ir-filter\", $DEVICE_INFO, \"icon\": \"mdi:image-filter-black-white\", \"state_topic\": \"$TOPIC/ir_cut\", \"command_topic\": \"$TOPIC/ir_cut/set\"}"
 
   # Light Sensor
   if [ "$LIGHT_SENSOR" != "false" ]; then
-	$MQTT_COMMAND "$AUTODISCOVERY_PREFIX/sensor/$DEVICE_NAME/light_sensor/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Light Sensor\", \"unique_id\": \"$MAC_SIMPLE-light-sensor\", $DEVICE_INFO, \"icon\": \"mdi:brightness-5\", \"unit_of_measurement\": \"%\", \"state_topic\": \"$TOPIC/brightness\"}"
+	$MQTT_COMMAND "$AUTODISCOVERY_PREFIX/sensor/$DEVICE_NAME/light_sensor/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Light Sensor\", \"unique_id\": \"$MAC_SIMPLE-light-sensor\", $DEVICE_INFO, \"icon\": \"mdi:brightness-5\", \"unit_of_measurement\": \"%\", \"state_topic\": \"$TOPIC/brightness\"}"
   fi
 
   # Night mode
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/night_mode/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Night Mode\", \"unique_id\": \"$MAC_SIMPLE-night-mode\", $DEVICE_INFO, \"icon\": \"mdi:weather-night\", \"state_topic\": \"$TOPIC/night_mode\", \"command_topic\": \"$TOPIC/night_mode/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/night_mode/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Night Mode\", \"unique_id\": \"$MAC_SIMPLE-night-mode\", $DEVICE_INFO, \"icon\": \"mdi:weather-night\", \"state_topic\": \"$TOPIC/night_mode\", \"command_topic\": \"$TOPIC/night_mode/set\"}"
 
   # Night mode automatic
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/auto_night_mode/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Auto Night Detection\", \"unique_id\": \"$MAC_SIMPLE-night-mode-auto\", $DEVICE_INFO, \"icon\": \"mdi:weather-night\", \"state_topic\": \"$TOPIC/night_mode/auto\", \"command_topic\": \"$TOPIC/night_mode/auto/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/auto_night_mode/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Auto Night Detection\", \"unique_id\": \"$MAC_SIMPLE-night-mode-auto\", $DEVICE_INFO, \"icon\": \"mdi:weather-night\", \"state_topic\": \"$TOPIC/night_mode/auto\", \"command_topic\": \"$TOPIC/night_mode/auto/set\"}"
 
   # RTSP Server
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/rtsp_server/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME RTSP Server\", \"unique_id\": \"$MAC_SIMPLE-rtsp-server\", $DEVICE_INFO, \"icon\": \"mdi:cctv\", \"state_topic\": \"$TOPIC/rtsp_server\", \"command_topic\": \"$TOPIC/rtsp_server/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/rtsp_server/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"RTSP Server\", \"unique_id\": \"$MAC_SIMPLE-rtsp-server\", $DEVICE_INFO, \"icon\": \"mdi:cctv\", \"state_topic\": \"$TOPIC/rtsp_server\", \"command_topic\": \"$TOPIC/rtsp_server/set\"}"
 
   # Motor up/down/left/right
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/cover/$DEVICE_NAME/motor_up_down/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME move up/down\", \"unique_id\": \"$MAC_SIMPLE-move-up-down\", $DEVICE_INFO, \"set_position_topic\": \"$TOPIC/motors/vertical/set\", \"position_topic\": \"$TOPIC/motors/vertical\", \"command_topic\": \"$TOPIC/motors/vertical/set\", \"payload_close\": \"down\", \"payload_open\": \"up\", \"optimistic\": \"false\", \"position_template\": \"{{ ((value|int)/($MAX_Y/$STEP))|round }}\", \"set_position_template\": \"{{ ((position|int)*($MAX_Y/$STEP))|round }}\"}"
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/cover/$DEVICE_NAME/motor_left_right/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME move left/right\", \"unique_id\": \"$MAC_SIMPLE-move-left-right\", $DEVICE_INFO, \"set_position_topic\": \"$TOPIC/motors/horizontal/set\", \"position_topic\": \"$TOPIC/motors/horizontal\", \"command_topic\": \"$TOPIC/motors/horizontal/set\", \"payload_close\": \"right\", \"payload_open\": \"left\", \"optimistic\": \"false\", \"position_template\": \"{{ ((value|int)/($MAX_X/$STEP))|round }}\", \"set_position_template\": \"{{ ((position|int)*($MAX_X/$STEP))|round }}\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/cover/$DEVICE_NAME/motor_up_down/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"move up/down\", \"unique_id\": \"$MAC_SIMPLE-move-up-down\", $DEVICE_INFO, \"set_position_topic\": \"$TOPIC/motors/vertical/set\", \"position_topic\": \"$TOPIC/motors/vertical\", \"command_topic\": \"$TOPIC/motors/vertical/set\", \"payload_close\": \"down\", \"payload_open\": \"up\", \"optimistic\": \"false\", \"position_template\": \"{{ ((value|int)/($MAX_Y/$STEP))|round }}\", \"set_position_template\": \"{{ ((position|int)*($MAX_Y/$STEP))|round }}\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/cover/$DEVICE_NAME/motor_left_right/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"move left/right\", \"unique_id\": \"$MAC_SIMPLE-move-left-right\", $DEVICE_INFO, \"set_position_topic\": \"$TOPIC/motors/horizontal/set\", \"position_topic\": \"$TOPIC/motors/horizontal\", \"command_topic\": \"$TOPIC/motors/horizontal/set\", \"payload_close\": \"right\", \"payload_open\": \"left\", \"optimistic\": \"false\", \"position_template\": \"{{ ((value|int)/($MAX_X/$STEP))|round }}\", \"set_position_template\": \"{{ ((position|int)*($MAX_X/$STEP))|round }}\"}"
 
   # Recording on/off switch
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/recording/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Recording\", \"unique_id\": \"$MAC_SIMPLE-recording\", $DEVICE_INFO, \"icon\": \"mdi:video\", \"state_topic\": \"$TOPIC/recording\", \"command_topic\": \"$TOPIC/recording/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/recording/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Recording\", \"unique_id\": \"$MAC_SIMPLE-recording\", $DEVICE_INFO, \"icon\": \"mdi:video\", \"state_topic\": \"$TOPIC/recording\", \"command_topic\": \"$TOPIC/recording/set\"}"
 
   # Timelapse on/off switch
-  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/timelapse/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"$DEVICE_NAME Timelapse\", \"unique_id\": \"$MAC_SIMPLE-timelapse\", $DEVICE_INFO, \"icon\": \"mdi:image-multiple\", \"state_topic\": \"$TOPIC/timelapse\", \"command_topic\": \"$TOPIC/timelapse/set\"}"
+  $MQTT_COMMAND "$AUTODISCOVERY_PREFIX/switch/$DEVICE_NAME/timelapse/config" ${MOSQUITTOPUBOPTS} ${MOSQUITTOOPTS} -r -m "{\"name\": \"Timelapse\", \"unique_id\": \"$MAC_SIMPLE-timelapse\", $DEVICE_INFO, \"icon\": \"mdi:image-multiple\", \"state_topic\": \"$TOPIC/timelapse\", \"command_topic\": \"$TOPIC/timelapse/set\"}"


### PR DESCRIPTION
Fix 2023.8 repair warning 'Discovered entities with a name that starts with the device name'

This stops working in version 2024.2.0. Please address before upgrading.

Some MQTT entities have an entity name that starts with the device name. This is not expected. To avoid a duplicate name the device name prefix is stripped of the entity name as a work-a-round. Please inform the maintainer of the software application that supplies the affected entities to fix this issue.