### PR TITLE
Update Gitter URLs as old ones returned a HTTP 404 Not Found

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 This is an issue tracking system only.
-If you have general questions or are a newbie, please ask for help in our [chat channel](https://gitter.im/Xiaomi-Dafang-Hacks).
+If you have general questions or are a newbie, please ask for help in our [chat channel](https://gitter.im/Xiaomi-Dafang-Hacks/Lobby).
 
 To make sure your issue can be resolved as quickly as possible please state your
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After that, continue to the
 ### Support
 
 If you encounter a problem, please see first if you find similiar open/closed issues. 
-Or ask in our [Gitter channel](https://gitter.im/Xiaomi-Dafang-Hacks) for help.
+Or ask in our [Gitter channel](https://gitter.im/Xiaomi-Dafang-Hacks/Lobby) for help.
 
 If you don't find anything related, feel free to open a new issue.
 If you/we solve your issue, please condense your gained insights into a pull request for continuous self-improvement.


### PR DESCRIPTION
With Gitter migration to Matrix platform, seems like a few of the URLs were not correct so I tweaked them so they now go directly to the discussion lobby.